### PR TITLE
Stop injecting the store into Preact components

### DIFF
--- a/packages/preact/src/createBinding.js
+++ b/packages/preact/src/createBinding.js
@@ -55,7 +55,7 @@ export const createBinding = ({ h, Component, createContext }) => {
         this.subscriptions = [];
       }
 
-      render({ children, ...other }) {
+      render({ children, store, ...other }) {
         return h(ChildComponent, { ...this.state, ...other }, children);
       }
     }


### PR DESCRIPTION
This breaks components that uses the store, use `dispatch` and injected state instead.