### PR TITLE
Revert "Allowing to bind actions in connect"

### DIFF
--- a/packages/preact/src/createBinding.js
+++ b/packages/preact/src/createBinding.js
@@ -11,6 +11,11 @@ export const createBinding = ({ h, Component, createContext }) => {
         const instanceId = nextId++;
         this.instanceId = instanceId;
 
+        const bindings =
+          typeof functionbindings === "function"
+            ? functionbindings({ instanceId, ...props })
+            : functionbindings;
+
         const store = props.store;
 
         const dispatch = (action) => {
@@ -19,22 +24,12 @@ export const createBinding = ({ h, Component, createContext }) => {
 
         this.state = { instanceId, dispatch };
 
-        const bindings =
-          typeof functionbindings === "function"
-            ? functionbindings({ ...this.state, ...props })
-            : functionbindings;
-
         this.observers = {};
 
         Object.keys(bindings || {}).forEach((name) => {
-          const binding = bindings[name];
-          if (typeof binding === "function") {
-            this.state[name] = binding;
-          } else {
-            const observer = store.observe(binding);
-            this.observers[name] = observer;
-            this.state[name] = observer.value;
-          }
+          const observer = store.observe(bindings[name]);
+          this.observers[name] = observer;
+          this.state[name] = observer.value;
         });
       }
 

--- a/packages/preact/src/index.spec.js
+++ b/packages/preact/src/index.spec.js
@@ -56,16 +56,21 @@ const incrementCounter = () => ({
 });
 
 const Widget = connect(
-  ({ id, instanceId, onClick, count }) => html`
-    <div id=${id}>
-      <span data-test-id="instanceId">${instanceId}<//>
-      <span data-test-id="count">${count}<//>
-      <button data-test-id="increment" onClick=${onClick}>Increment<//>
-    </div>
-  `,
-  ({ dispatch, instanceId }) => ({
-    count: `widgets.${instanceId}.counter`,
-    onClick: () => dispatch(incrementCounter()),
+  ({ dispatch, id, instanceId, count }) => {
+    const onClick = () => {
+      dispatch(incrementCounter());
+    };
+
+    return html`
+      <div id=${id}>
+        <span data-test-id="instanceId">${instanceId}<//>
+        <span data-test-id="count">${count}<//>
+        <button data-test-id="increment" onClick=${onClick}>Increment<//>
+      </div>
+    `;
+  },
+  (props) => ({
+    count: `widgets.${props.instanceId}.counter`,
   })
 );
 


### PR DESCRIPTION
I realised that `connect` only runs on mount, so you will not have the updated props, which I think will create confusion.

Reverts sunesimonsen/depository#9