### PR TITLE
Return the patch to the store from action.apply

### DIFF
--- a/examples/todomvc/package-lock.json
+++ b/examples/todomvc/package-lock.json
@@ -1,0 +1,998 @@
+{
+	"name": "todomvc",
+	"version": "0.16.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"mocha": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
+			"dev": true,
+			"requires": {
+				"@ungap/promise-all-settled": "1.1.2",
+				"ansi-colors": "4.1.1",
+				"browser-stdout": "1.3.1",
+				"chokidar": "3.4.3",
+				"debug": "4.2.0",
+				"diff": "4.0.2",
+				"escape-string-regexp": "4.0.0",
+				"find-up": "5.0.0",
+				"glob": "7.1.6",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.14.0",
+				"log-symbols": "4.0.0",
+				"minimatch": "3.0.4",
+				"ms": "2.1.2",
+				"nanoid": "3.1.12",
+				"serialize-javascript": "5.0.1",
+				"strip-json-comments": "3.1.1",
+				"supports-color": "7.2.0",
+				"which": "2.0.2",
+				"wide-align": "1.1.3",
+				"workerpool": "6.0.2",
+				"yargs": "13.3.2",
+				"yargs-parser": "13.1.2",
+				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"@ungap/promise-all-settled": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+					"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+					"dev": true
+				},
+				"ansi-colors": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true
+				},
+				"binary-extensions": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+					"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"browser-stdout": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+					"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"chokidar": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+					"dev": true,
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.2",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.5.0"
+					}
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
+				},
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"flat": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+					"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+					"dev": true
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"dev": true,
+					"optional": true
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"growl": {
+					"version": "1.10.5",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+					"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"he": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+					"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"is-binary-path": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+					"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+					"dev": true,
+					"requires": {
+						"binary-extensions": "^2.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"log-symbols": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+					"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"nanoid": {
+					"version": "3.1.12",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+					"dev": true
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+					"dev": true
+				},
+				"randombytes": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+					"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.1.0"
+					}
+				},
+				"readdirp": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+					"dev": true,
+					"requires": {
+						"picomatch": "^2.2.1"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				},
+				"serialize-javascript": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+					"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"dev": true
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
+				},
+				"wide-align": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.2 || 2"
+					}
+				},
+				"workerpool": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+					"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"color-convert": {
+							"version": "1.9.3",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+							"dev": true,
+							"requires": {
+								"color-name": "1.1.3"
+							}
+						},
+						"color-name": {
+							"version": "1.1.3",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				},
+				"y18n": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+					"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"find-up": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"dev": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+							"dev": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				},
+				"yargs-unparser": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+					"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^6.0.0",
+						"decamelize": "^4.0.0",
+						"flat": "^5.0.2",
+						"is-plain-obj": "^2.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "6.2.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+							"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+							"dev": true
+						},
+						"decamelize": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+							"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+							"dev": true
+						}
+					}
+				},
+				"yocto-queue": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+					"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+					"dev": true
+				}
+			}
+		},
+		"rollup": {
+			"version": "2.38.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.1.tgz",
+			"integrity": "sha512-q07T6vU/V1kqM8rGRRyCgEvIQcIAXoKIE5CpkYAlHhfiWM1Iuh4dIPWpIbqFngCK6lwAB2aYHiUVhIbSWHQWhw==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.1.2"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"unexpected": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/unexpected/-/unexpected-12.0.0.tgz",
+			"integrity": "sha512-fvfae3tGahPNRp3biVWDVGj/E3XHsD1uOr9/nf9cxV5zaaAtncRu2L2sVOeU2e3BJ7+kfVSyo/vakECBykPA6g==",
+			"dev": true,
+			"requires": {
+				"array-changes": "3.0.1",
+				"array-changes-async": "3.0.1",
+				"detect-indent": "3.0.1",
+				"diff": "^5.0.0",
+				"greedy-interval-packer": "1.2.0",
+				"magicpen": "^6.2.1",
+				"ukkonen": "^1.4.0",
+				"unexpected-bluebird": "2.9.34-longstack2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.0.tgz",
+					"integrity": "sha1-QysmFi/qG2PIeIlqvIzFVI8lBj4=",
+					"dev": true
+				},
+				"array-changes": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/array-changes/-/array-changes-3.0.1.tgz",
+					"integrity": "sha512-UYXV+qUaTKJO3GUBVfD6b9Mu7wUzDvpfovZKtbxNJApwRUifgrJMidvE+/rbqV3wCffly5HXcbOW3/7shmmEag==",
+					"dev": true,
+					"requires": {
+						"arraydiff-papandreou": "0.1.1-patch1"
+					}
+				},
+				"array-changes-async": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/array-changes-async/-/array-changes-async-3.0.1.tgz",
+					"integrity": "sha512-WNHLhMOTzntixkBxNm/MiWCNKuC4FMYXk6DKuzZUbkWXAe0Xomwv40SEUicfOuHHtW7Ue661Mc5AJA0AOfqApg==",
+					"dev": true,
+					"requires": {
+						"arraydiff-async": "0.2.0"
+					}
+				},
+				"arraydiff-async": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/arraydiff-async/-/arraydiff-async-0.2.0.tgz",
+					"integrity": "sha1-uwUouY6BS3AvAfSWvHO+w+V/QIY=",
+					"dev": true
+				},
+				"arraydiff-papandreou": {
+					"version": "0.1.1-patch1",
+					"resolved": "https://registry.npmjs.org/arraydiff-papandreou/-/arraydiff-papandreou-0.1.1-patch1.tgz",
+					"integrity": "sha1-ApAnC/27Sy762LdIJjitWnIQkhA=",
+					"dev": true
+				},
+				"color-diff": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
+					"integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
+					"dev": true
+				},
+				"detect-indent": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+					"integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+					"dev": true,
+					"requires": {
+						"get-stdin": "^4.0.1",
+						"minimist": "^1.1.0",
+						"repeating": "^1.1.0"
+					}
+				},
+				"diff": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+					"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+					"dev": true
+				},
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+					"dev": true
+				},
+				"greedy-interval-packer": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/greedy-interval-packer/-/greedy-interval-packer-1.2.0.tgz",
+					"integrity": "sha1-1toR82Ybt5eBLaeKHqUQZ4oqhzk=",
+					"dev": true
+				},
+				"is-finite": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+					"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+					"dev": true
+				},
+				"magicpen": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/magicpen/-/magicpen-6.2.1.tgz",
+					"integrity": "sha512-JEkzC2hJmoCRTC8v1lgLIi75aF8pAz72kYZ9l/EorRnBXavPErnBywm/ec3xTDjCPBonsdhNZoRzj+TUfbCYJg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.0.0",
+						"color-diff": "0.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"repeating": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+					"integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+					"dev": true,
+					"requires": {
+						"is-finite": "^1.0.0"
+					}
+				},
+				"ukkonen": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ukkonen/-/ukkonen-1.4.0.tgz",
+					"integrity": "sha512-g8SLGxflI0/VNH2C8j66KcfJXrU5StJglRQBYPNiChXFlOrqqYM1icOykOAAUgTeBpktaEuCm9hjpPinQ080PA==",
+					"dev": true
+				},
+				"unexpected-bluebird": {
+					"version": "2.9.34-longstack2",
+					"resolved": "https://registry.npmjs.org/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz",
+					"integrity": "sha1-SaysdTsFVt7WAlIQ7pYYIwfSssk=",
+					"dev": true
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11196,7 +11196,10 @@
     "wmr": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/wmr/-/wmr-1.1.0.tgz",
-      "integrity": "sha512-ELll+l3wegNmYmPLoWUnPBzlv20we4zlM7jfKqP1tzYus8HUil65e8tNug2Vxbd++ROtT9qL54Qmo0DRze66tQ=="
+      "integrity": "sha512-ELll+l3wegNmYmPLoWUnPBzlv20we4zlM7jfKqP1tzYus8HUil65e8tNug2Vxbd++ROtT9qL54Qmo0DRze66tQ==",
+      "requires": {
+        "fsevents": "^2.1.3"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1440,12 +1440,12 @@
       "integrity": "sha512-pKWm8K4bGlkgHuyux1dbs6f/7n1lIvHQ+n6z6mHPspqdn27z2tBaXXtap5XMPW8DmuyFXQIqjXZ3GSc/SgAInA=="
     },
     "@nano-router/router": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nano-router/router/-/router-2.4.0.tgz",
-      "integrity": "sha512-6izPeUqx+7Eqgy+0vzSslhYW6+Reix9pHG/oLDAiN/heB72QPLLR8Zk2cV5tRxmZHeg/wfZ4Z718bbyXaY4nSw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nano-router/router/-/router-2.5.0.tgz",
+      "integrity": "sha512-alWlYyoB4mjZODO1gYPb0f9/w33+u5OsiBNku+AausspoHGYBNgvuDzoes6UOe+z7g/ASo27kXdws9CWHgTgeA==",
       "requires": {
         "@nano-router/routes": "^2.3.0",
-        "@nano-router/url": "^2.4.0",
+        "@nano-router/url": "^2.5.0",
         "querystring": "^0.2.0"
       }
     },
@@ -1458,9 +1458,9 @@
       }
     },
     "@nano-router/url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nano-router/url/-/url-2.4.0.tgz",
-      "integrity": "sha512-F+iPQQMzhF8LMsByAZx5marNm7SqkJUS0rO68FFkXRbdOvTjmxWVRSVwaYVuAGEl9z6W6LX3NNtdCeIqK+JEfg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nano-router/url/-/url-2.5.0.tgz",
+      "integrity": "sha512-rR6X1siIoNzlN9TgtfLSTEMRwrfxgVpXtxZmmToa2BSF6MKIGdBh5ExnJq9LNlcL21dgZNGBLMj+8Bnor5a0cA==",
       "requires": {
         "@nano-router/path": "^2.3.0",
         "querystring": "^0.2.0"
@@ -1656,18 +1656,18 @@
       }
     },
     "@rollup/plugin-babel": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz",
-      "integrity": "sha512-MjmH7GvFT4TW8xFdIeFS3wqIX646y5tACdxkTO+khbHvS3ZcVJL6vkAHLw2wqPmkhwCfWHoNsp15VYNwW6JEJA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.3.tgz",
+      "integrity": "sha512-DOMc7nx6y5xFi86AotrFssQqCen6CxYn+zts5KSI879d4n1hggSb4TH3mjVgG17Vc3lZziWWfcXzrEmVdzPMdw==",
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@rollup/pluginutils": "^3.1.0"
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.0.0.tgz",
-      "integrity": "sha512-/omBIJG1nHQc+bgkYDuLpb/V08QyutP9amOrJRUSlYJZP+b/68gM//D8sxJe3Yry2QnYIr3QjR3x4AlxJEN3GA==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.1.0.tgz",
+      "integrity": "sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==",
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "commondir": "^1.0.1",
@@ -1686,9 +1686,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.1.0.tgz",
-      "integrity": "sha512-ouBBppRdWJKCllDXGzJ7ZIkYbaq+5TmyP0smt1vdJCFfoZhLi31vhpmjLhyo8lreHf4RoeSNllaWrvSqHpHRog==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.1.1.tgz",
+      "integrity": "sha512-zlBXR4eRS+2m79TsUZWhsd0slrHUYdRx4JF+aVQm+MI0wsKdlpC2vlDVjmlGvtZY1vsefOT9w3JxvmWSBei+Lg==",
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
@@ -8619,9 +8619,9 @@
       "dev": true
     },
     "preact": {
-      "version": "10.5.11",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.11.tgz",
-      "integrity": "sha512-BdtFePVilR1430kDuzh3VkkZktCmp8RTqHOjG8qesyGZXHNYJjdrjEBuc2f7O/vthhVENxJd0/aTjWtYeH46aw=="
+      "version": "10.5.12",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.12.tgz",
+      "integrity": "sha512-r6siDkuD36oszwlCkcqDJCAKBQxGoeEGytw2DGMD5A/GGdu5Tymw+N2OBXwvOLxg6d1FeY8MgMV3cc5aVQo4Cg=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -9181,9 +9181,9 @@
       }
     },
     "rollup": {
-      "version": "2.37.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.37.1.tgz",
-      "integrity": "sha512-V3ojEeyGeSdrMSuhP3diBb06P+qV4gKQeanbDv+Qh/BZbhdZ7kHV0xAt8Yjk4GFshq/WjO7R4c7DFM20AwTFVQ==",
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.1.tgz",
+      "integrity": "sha512-q07T6vU/V1kqM8rGRRyCgEvIQcIAXoKIE5CpkYAlHhfiWM1Iuh4dIPWpIbqFngCK6lwAB2aYHiUVhIbSWHQWhw==",
       "requires": {
         "fsevents": "~2.1.2"
       }
@@ -9463,13 +9463,13 @@
       "integrity": "sha1-UJ83gk3RAq+KscA7yw5deRDl3s8="
     },
     "sinon": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.3.tgz",
-      "integrity": "sha512-m+DyAWvqVHZtjnjX/nuShasykFeiZ+nPuEfD4G3gpvKGkXRhkF/6NSt2qN2FjZhfrcHXFzUzI+NLnk+42fnLEw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.0",
+        "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
@@ -10363,16 +10363,6 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         }
       }
-    },
-    "todomvc-app-css": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.3.0.tgz",
-      "integrity": "sha512-RG8hxqoVn8Be3wxyuyHfOSAXiY1Z0N+PYQOe/jxzy3wpU1Obfwd1RF1i/fz/fR+MrYL+Q+BdrUt8SsXdtR7Oow=="
-    },
-    "todomvc-common": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/todomvc-common/-/todomvc-common-1.0.5.tgz",
-      "integrity": "sha512-D8kEJmxVMQIWwztEdH+WeiAfXRbbSCpgXq4NkYi+gduJ2tr8CNq7sYLfJvjpQ10KD9QxJwig57rvMbV2QAESwQ=="
     },
     "toml": {
       "version": "2.3.6",

--- a/packages/nano-router-plugin/package-lock.json
+++ b/packages/nano-router-plugin/package-lock.json
@@ -1,0 +1,219 @@
+{
+	"name": "@depository/nano-router-plugin",
+	"version": "0.16.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"unexpected": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/unexpected/-/unexpected-12.0.0.tgz",
+			"integrity": "sha512-fvfae3tGahPNRp3biVWDVGj/E3XHsD1uOr9/nf9cxV5zaaAtncRu2L2sVOeU2e3BJ7+kfVSyo/vakECBykPA6g==",
+			"dev": true,
+			"requires": {
+				"array-changes": "3.0.1",
+				"array-changes-async": "3.0.1",
+				"detect-indent": "3.0.1",
+				"diff": "^5.0.0",
+				"greedy-interval-packer": "1.2.0",
+				"magicpen": "^6.2.1",
+				"ukkonen": "^1.4.0",
+				"unexpected-bluebird": "2.9.34-longstack2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.0.tgz",
+					"integrity": "sha1-QysmFi/qG2PIeIlqvIzFVI8lBj4=",
+					"dev": true
+				},
+				"array-changes": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/array-changes/-/array-changes-3.0.1.tgz",
+					"integrity": "sha512-UYXV+qUaTKJO3GUBVfD6b9Mu7wUzDvpfovZKtbxNJApwRUifgrJMidvE+/rbqV3wCffly5HXcbOW3/7shmmEag==",
+					"dev": true,
+					"requires": {
+						"arraydiff-papandreou": "0.1.1-patch1"
+					}
+				},
+				"array-changes-async": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/array-changes-async/-/array-changes-async-3.0.1.tgz",
+					"integrity": "sha512-WNHLhMOTzntixkBxNm/MiWCNKuC4FMYXk6DKuzZUbkWXAe0Xomwv40SEUicfOuHHtW7Ue661Mc5AJA0AOfqApg==",
+					"dev": true,
+					"requires": {
+						"arraydiff-async": "0.2.0"
+					}
+				},
+				"arraydiff-async": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/arraydiff-async/-/arraydiff-async-0.2.0.tgz",
+					"integrity": "sha1-uwUouY6BS3AvAfSWvHO+w+V/QIY=",
+					"dev": true
+				},
+				"arraydiff-papandreou": {
+					"version": "0.1.1-patch1",
+					"resolved": "https://registry.npmjs.org/arraydiff-papandreou/-/arraydiff-papandreou-0.1.1-patch1.tgz",
+					"integrity": "sha1-ApAnC/27Sy762LdIJjitWnIQkhA=",
+					"dev": true
+				},
+				"color-diff": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
+					"integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
+					"dev": true
+				},
+				"detect-indent": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+					"integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+					"dev": true,
+					"requires": {
+						"get-stdin": "^4.0.1",
+						"minimist": "^1.1.0",
+						"repeating": "^1.1.0"
+					}
+				},
+				"diff": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+					"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+					"dev": true
+				},
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+					"dev": true
+				},
+				"greedy-interval-packer": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/greedy-interval-packer/-/greedy-interval-packer-1.2.0.tgz",
+					"integrity": "sha1-1toR82Ybt5eBLaeKHqUQZ4oqhzk=",
+					"dev": true
+				},
+				"is-finite": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+					"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+					"dev": true
+				},
+				"magicpen": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/magicpen/-/magicpen-6.2.1.tgz",
+					"integrity": "sha512-JEkzC2hJmoCRTC8v1lgLIi75aF8pAz72kYZ9l/EorRnBXavPErnBywm/ec3xTDjCPBonsdhNZoRzj+TUfbCYJg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.0.0",
+						"color-diff": "0.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"repeating": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+					"integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+					"dev": true,
+					"requires": {
+						"is-finite": "^1.0.0"
+					}
+				},
+				"ukkonen": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ukkonen/-/ukkonen-1.4.0.tgz",
+					"integrity": "sha512-g8SLGxflI0/VNH2C8j66KcfJXrU5StJglRQBYPNiChXFlOrqqYM1icOykOAAUgTeBpktaEuCm9hjpPinQ080PA==",
+					"dev": true
+				},
+				"unexpected-bluebird": {
+					"version": "2.9.34-longstack2",
+					"resolved": "https://registry.npmjs.org/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz",
+					"integrity": "sha1-SaysdTsFVt7WAlIQ7pYYIwfSssk=",
+					"dev": true
+				}
+			}
+		},
+		"unexpected-dom": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unexpected-dom/-/unexpected-dom-5.0.0.tgz",
+			"integrity": "sha512-K25jbQ3cKWMflxUFB60ZZa6RWZSLoRC1VWFumTkSIddUG/eJCJpnFDzvfZt6n7ZIMO92GAtRy/+Quod7QSDriA==",
+			"dev": true,
+			"requires": {
+				"extend": "^3.0.1",
+				"magicpen-prism": "^4.0.0"
+			},
+			"dependencies": {
+				"clipboard": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+					"integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"good-listener": "^1.2.2",
+						"select": "^1.1.2",
+						"tiny-emitter": "^2.0.0"
+					}
+				},
+				"delegate": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+					"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+					"dev": true,
+					"optional": true
+				},
+				"extend": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+					"dev": true
+				},
+				"good-listener": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+					"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegate": "^3.1.2"
+					}
+				},
+				"magicpen-prism": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/magicpen-prism/-/magicpen-prism-4.1.1.tgz",
+					"integrity": "sha512-WiW87nVxaipTFw2EO6Vp4KJ/PIyVtfrE33T8x8NqaYYj+eUrVxcnJS+GY/ioD+MwH4EnU1xBSnLxHcGFLAKrhw==",
+					"dev": true,
+					"requires": {
+						"prismjs": "^1.21.0"
+					}
+				},
+				"prismjs": {
+					"version": "1.23.0",
+					"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+					"integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+					"dev": true,
+					"requires": {
+						"clipboard": "^2.0.0"
+					}
+				},
+				"select": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+					"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+					"dev": true,
+					"optional": true
+				},
+				"tiny-emitter": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+					"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		}
+	}
+}

--- a/packages/nano-router-plugin/src/index.js
+++ b/packages/nano-router-plugin/src/index.js
@@ -6,12 +6,13 @@ export const nanoRouterPlugin = ({ routes, history }) => (store) => {
   const updateRouting = () => {
     store.dispatch({
       payload: {
-        route: router.route,
-        location: router.location,
-        params: router.params,
-        queryParams: router.queryParams,
+        routing: {
+          route: router.route,
+          location: router.location,
+          params: router.params,
+          queryParams: router.queryParams,
+        },
       },
-      apply: (routing) => ({ routing }),
     });
   };
 

--- a/packages/nano-router-plugin/src/index.js
+++ b/packages/nano-router-plugin/src/index.js
@@ -11,9 +11,7 @@ export const nanoRouterPlugin = ({ routes, history }) => (store) => {
         params: router.params,
         queryParams: router.queryParams,
       },
-      apply: (cache, { payload }) => {
-        cache.set("routing", payload);
-      },
+      apply: (routing) => ({ routing }),
     });
   };
 

--- a/packages/nano-router-plugin/src/preact/usePrompt.spec.js
+++ b/packages/nano-router-plugin/src/preact/usePrompt.spec.js
@@ -40,8 +40,7 @@ const isDirty = {
 };
 
 const updateName = (newName) => ({
-  payload: newName,
-  apply: { [namePath]: newName },
+  payload: { [namePath]: newName },
 });
 
 const NewView = () => {

--- a/packages/nano-router-plugin/src/preact/usePrompt.spec.js
+++ b/packages/nano-router-plugin/src/preact/usePrompt.spec.js
@@ -41,9 +41,7 @@ const isDirty = {
 
 const updateName = (newName) => ({
   payload: newName,
-  apply: (cache, { payload }) => {
-    cache.set(namePath, payload);
-  },
+  apply: { [namePath]: newName },
 });
 
 const NewView = () => {

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@depository/store": "^0.16.0",
+    "@depository/promise-middleware": "^0.16.0",
     "htm": "^3.0.4",
     "jsdom": "^16.4.0",
     "mocha": "8.2.1",

--- a/packages/preact/src/hooks/useObservable.spec.js
+++ b/packages/preact/src/hooks/useObservable.spec.js
@@ -23,9 +23,11 @@ const computedSum = {
 };
 
 const increment = () => ({
-  apply: (cache) => {
-    cache.update("(a|b)", (v) => v + 1);
-  },
+  payload: (cache) => cache.get("{a,b}"),
+  apply: ({ a, b }) => ({
+    a: a + 1,
+    b: b + 1,
+  }),
 });
 
 const Calculator = () => {

--- a/packages/preact/src/hooks/useObservable.spec.js
+++ b/packages/preact/src/hooks/useObservable.spec.js
@@ -2,6 +2,7 @@ import unexpected from "unexpected";
 import unexpectedDom from "unexpected-dom";
 import simulateEvents from "simulate-events";
 import { Store } from "@depository/store";
+import { promiseMiddleware } from "@depository/promise-middleware";
 import { StoreProvider, useObservable, useDispatch } from "./index.js";
 import { h, render } from "preact";
 import htm from "htm";
@@ -23,11 +24,13 @@ const computedSum = {
 };
 
 const increment = () => ({
-  payload: (cache) => cache.get("{a,b}"),
-  apply: ({ a, b }) => ({
-    a: a + 1,
-    b: b + 1,
-  }),
+  payload: (cache) => {
+    const { a, b } = cache.get("{a,b}");
+    return {
+      a: a + 1,
+      b: b + 1,
+    };
+  },
 });
 
 const Calculator = () => {
@@ -58,6 +61,8 @@ describe("useObservable", () => {
       a: 10,
       b: 10,
     });
+
+    store.useMiddleware(promiseMiddleware());
 
     render(
       html`<${StoreProvider} value=${store}><${Calculator} /><//>`,

--- a/packages/preact/src/index.spec.js
+++ b/packages/preact/src/index.spec.js
@@ -2,6 +2,7 @@ import unexpected from "unexpected";
 import unexpectedDom from "unexpected-dom";
 import simulateEvents from "simulate-events";
 import { Store } from "@depository/store";
+import { promiseMiddleware } from "@depository/promise-middleware";
 import { StoreProvider, connect } from "./index.js";
 import { h, render } from "preact";
 import htm from "htm";
@@ -23,11 +24,13 @@ const sum = {
 };
 
 const increment = () => ({
-  payload: (cache) => cache.get("{a,b}"),
-  apply: ({ a, b }) => ({
-    a: a + 1,
-    b: b + 1,
-  }),
+  payload: (cache) => {
+    const { a, b } = cache.get("{a,b}");
+    return {
+      a: a + 1,
+      b: b + 1,
+    };
+  },
 });
 
 const Calculator = connect(
@@ -56,6 +59,8 @@ describe("preact", () => {
       a: 10,
       b: 10,
     });
+
+    store.useMiddleware(promiseMiddleware());
 
     render(
       html`<${StoreProvider} value=${store}><${Calculator} /><//>`,

--- a/packages/preact/src/index.spec.js
+++ b/packages/preact/src/index.spec.js
@@ -23,9 +23,11 @@ const sum = {
 };
 
 const increment = () => ({
-  apply: (cache) => {
-    cache.update("(a|b)", (v) => v + 1);
-  },
+  payload: (cache) => cache.get("{a,b}"),
+  apply: ({ a, b }) => ({
+    a: a + 1,
+    b: b + 1,
+  }),
 });
 
 const Calculator = connect(

--- a/packages/promise-middleware/src/index.js
+++ b/packages/promise-middleware/src/index.js
@@ -1,3 +1,7 @@
+const readonlyCache = (cache) => ({
+  get: cache.get.bind(cache),
+});
+
 export const promiseMiddleware = (...args) => async ({
   store,
   next,
@@ -9,6 +13,6 @@ export const promiseMiddleware = (...args) => async ({
 
   return next({
     ...action,
-    payload: await action.payload(store.cache, ...args),
+    payload: await action.payload(readonlyCache(store.cache), ...args),
   });
 };

--- a/packages/promise-middleware/src/index.js
+++ b/packages/promise-middleware/src/index.js
@@ -21,7 +21,7 @@ export const promiseMiddleware = (...args) => async ({
       payload,
     });
   } catch (error) {
-    next({
+    await next({
       ...action,
       payload: null,
       error,

--- a/packages/promise-middleware/src/index.js
+++ b/packages/promise-middleware/src/index.js
@@ -3,30 +3,12 @@ export const promiseMiddleware = (...args) => async ({
   next,
   action,
 }) => {
-  let payload = action.payload;
-
-  if (!payload) {
+  if (!action.payload || typeof action.payload !== "function") {
     return next(action);
   }
 
-  try {
-    if (typeof payload === "function") {
-      payload = await payload(store.cache, ...args);
-    } else {
-      payload = await payload;
-    }
-
-    return next({
-      ...action,
-      payload,
-    });
-  } catch (error) {
-    await next({
-      ...action,
-      payload: null,
-      error,
-    });
-
-    throw error;
-  }
+  return next({
+    ...action,
+    payload: await action.payload(store.cache, ...args),
+  });
 };

--- a/packages/promise-middleware/src/index.spec.js
+++ b/packages/promise-middleware/src/index.spec.js
@@ -22,9 +22,9 @@ describe("promise-middleware", () => {
   it("resolve promise payloads", async () => {
     await store.dispatch({
       payload: fakeApi.getTestValue(),
-      apply: (store, { payload }) => {
-        store.set("response", payload);
-      },
+      apply: (response) => ({
+        response,
+      }),
     });
 
     expect(store.get(), "to equal", {
@@ -35,9 +35,9 @@ describe("promise-middleware", () => {
   it("resolves async function payloads", async () => {
     await store.dispatch({
       payload: (cache, api) => api.getTestValue(),
-      apply: (store, { payload }) => {
-        store.set("response", payload);
-      },
+      apply: (response) => ({
+        response,
+      }),
     });
 
     expect(store.get(), "to equal", {
@@ -48,13 +48,13 @@ describe("promise-middleware", () => {
   it("forwards promise rejections as the payload", async () => {
     await store.dispatch({
       payload: (cache, api) => api.deadEnd(),
-      apply: (store, { error }) => {
-        store.set("response", error);
+      apply: (response, { error }) => {
+        return error ? { error: error.message } : { response };
       },
     });
 
     expect(store.get(), "to equal", {
-      response: new Error("Dead end!"),
+      error: "Dead end!",
     });
   });
 });

--- a/packages/status-middleware/src/index.js
+++ b/packages/status-middleware/src/index.js
@@ -9,16 +9,17 @@ export const statusMiddleware = (...args) => async ({
   action,
 }) => {
   const execution = next(action);
+  const key = `statuses.${action.status}`;
 
   if (isPromise(execution) && action.status) {
     try {
-      store.cache.set(`statuses.${action.status}`, "loading");
+      store.cache.set(key, "loading");
       store.cache.notify();
       const result = await execution;
-      store.cache.set(`statuses.${action.status}`, "ready");
+      await next({ apply: { [key]: "ready" } });
       return result;
     } catch (e) {
-      store.cache.set(`statuses.${action.status}`, "failed");
+      await next({ apply: { [key]: "failed" } });
       throw e;
     }
   } else {

--- a/packages/status-middleware/src/index.js
+++ b/packages/status-middleware/src/index.js
@@ -16,10 +16,10 @@ export const statusMiddleware = (...args) => async ({
       store.cache.set(key, "loading");
       store.cache.notify();
       const result = await execution;
-      await next({ apply: { [key]: "ready" } });
+      await next({ payload: { [key]: "ready" } });
       return result;
     } catch (e) {
-      await next({ apply: { [key]: "failed" } });
+      await next({ payload: { [key]: "failed" } });
       throw e;
     }
   } else {

--- a/packages/status-middleware/src/index.spec.js
+++ b/packages/status-middleware/src/index.spec.js
@@ -30,9 +30,7 @@ describe("status-middleware", () => {
     const dispatchPromise = store.dispatch({
       status: "test-value",
       payload: fakeApi.getTestValue(),
-      apply: (store, { payload }) => {
-        store.set("response", payload);
-      },
+      apply: (payload) => ({ response: payload }),
     });
 
     expect(store.get(), "to equal", {
@@ -51,9 +49,7 @@ describe("status-middleware", () => {
     const dispatchPromise = store.dispatch({
       status: "test-value",
       payload: (cache, api) => api.getTestValue(),
-      apply: (store, { payload }) => {
-        store.set("response", payload);
-      },
+      apply: (payload) => ({ response: payload }),
     });
 
     expect(store.get(), "to equal", {
@@ -72,9 +68,7 @@ describe("status-middleware", () => {
     const dispatchPromise = store.dispatch({
       status: "test-value",
       payload: (cache, api) => api.deadEnd(),
-      apply: (store, { error }) => {
-        store.set("response", error);
-      },
+      apply: (response, { error }) => ({ error: error.message }),
     });
 
     expect(store.get(), "to equal", {
@@ -85,7 +79,7 @@ describe("status-middleware", () => {
 
     expect(store.get(), "to equal", {
       statuses: { "test-value": "failed" },
-      response: Error("Dead end!"),
+      error: "Dead end!",
     });
   });
 
@@ -96,9 +90,7 @@ describe("status-middleware", () => {
     await store.dispatch({
       status: "test-value",
       payload: fakeApi.getTestValue(),
-      apply: (store, { payload }) => {
-        store.set("response", payload);
-      },
+      apply: (response) => ({ response }),
     });
 
     expect(store.get(), "to equal", {

--- a/packages/store/src/Store.js
+++ b/packages/store/src/Store.js
@@ -4,17 +4,7 @@ export class Store {
   constructor(data) {
     this.cache = new Cache(data);
     this._apply = (action) => {
-      const payload =
-        typeof action.payload === "function"
-          ? action.payload(this.cache)
-          : action.payload;
-
-      const patch =
-        typeof action.apply === "function"
-          ? action.apply(payload, action)
-          : action.apply;
-
-      Object.entries(patch).forEach(([pathPattern, value]) => {
+      Object.entries(action.payload).forEach(([pathPattern, value]) => {
         this.cache.set(pathPattern, value);
       });
     };
@@ -41,8 +31,6 @@ export class Store {
   async dispatch(action) {
     try {
       await this._apply(action);
-    } catch (e) {
-      console.error(e);
     } finally {
       this.cache.notify();
     }

--- a/packages/store/src/Store.js
+++ b/packages/store/src/Store.js
@@ -4,7 +4,19 @@ export class Store {
   constructor(data) {
     this.cache = new Cache(data);
     this._apply = (action) => {
-      action.apply(this.cache, action);
+      const payload =
+        typeof action.payload === "function"
+          ? action.payload(this.cache)
+          : action.payload;
+
+      const patch =
+        typeof action.apply === "function"
+          ? action.apply(payload, action)
+          : action.apply;
+
+      Object.entries(patch).forEach(([pathPattern, value]) => {
+        this.cache.set(pathPattern, value);
+      });
     };
   }
 

--- a/packages/store/src/Store.spec.js
+++ b/packages/store/src/Store.spec.js
@@ -35,10 +35,11 @@ describe("store", () => {
         });
 
         await store.dispatch({
-          apply: (cache) => {
-            cache.update("global.testing", (v) => v.toUpperCase());
-            cache.set("global.extra", "Fresh out of the gate");
-          },
+          payload: (cache) => cache.get("global.testing").toUpperCase(),
+          apply: (testing) => ({
+            "global.testing": testing.toUpperCase(),
+            "global.extra": "Fresh out of the gate",
+          }),
         });
 
         expect(store.get(), "to equal", {
@@ -70,10 +71,7 @@ describe("store", () => {
       multipy.subscribe(computedSpy);
 
       await store.dispatch({
-        apply: (cache) => {
-          cache.set("a", 2);
-          cache.set("b", 4);
-        },
+        apply: { a: 2, b: 4 },
       });
 
       expect(store.get(), "to equal", {
@@ -128,9 +126,10 @@ describe("store", () => {
 
       await store.dispatch({
         type: "upper-case",
-        apply: (cache) => {
-          cache.update("global.testing", (v) => v.toUpperCase());
-        },
+        payload: (cache) => cache.get("global.testing").toUpperCase(),
+        apply: (testing) => ({
+          "global.testing": testing,
+        }),
       });
 
       expect(store.get(), "to equal", {

--- a/packages/store/src/Store.spec.js
+++ b/packages/store/src/Store.spec.js
@@ -28,23 +28,20 @@ describe("store", () => {
   });
 
   describe("dispatch", () => {
-    describe("when the action doesn't contain a path", () => {
-      it("executes the given action against the entire store", async () => {
-        const store = new Store({
-          global: { testing: "The state" },
-        });
+    it("patches the store with the payload", async () => {
+      const store = new Store({
+        global: { testing: "The state" },
+      });
 
-        await store.dispatch({
-          payload: (cache) => cache.get("global.testing").toUpperCase(),
-          apply: (testing) => ({
-            "global.testing": testing.toUpperCase(),
-            "global.extra": "Fresh out of the gate",
-          }),
-        });
+      await store.dispatch({
+        payload: {
+          "global.testing": "THE STATE",
+          "global.extra": "Fresh out of the gate",
+        },
+      });
 
-        expect(store.get(), "to equal", {
-          global: { testing: "THE STATE", extra: "Fresh out of the gate" },
-        });
+      expect(store.get(), "to equal", {
+        global: { testing: "THE STATE", extra: "Fresh out of the gate" },
       });
     });
 
@@ -71,7 +68,7 @@ describe("store", () => {
       multipy.subscribe(computedSpy);
 
       await store.dispatch({
-        apply: { a: 2, b: 4 },
+        payload: { a: 2, b: 4 },
       });
 
       expect(store.get(), "to equal", {
@@ -126,10 +123,9 @@ describe("store", () => {
 
       await store.dispatch({
         type: "upper-case",
-        payload: (cache) => cache.get("global.testing").toUpperCase(),
-        apply: (testing) => ({
-          "global.testing": testing,
-        }),
+        payload: {
+          "global.testing": "THE STATE",
+        },
       });
 
       expect(store.get(), "to equal", {


### PR DESCRIPTION
Merged `payload` and `apply` on actions and only accept cache patches at for actions entering the store.
The promise middleware takes care of supporting function and async function payloads and converts them into a cache patch.

This kind of change will make it a lot easier to create a logging middleware, action persistence and devtools.

Example logging middleware:

```js
store.useMiddleware(({ next, action }) => {
  console.log(action.payload);
  return next(action);
});
```

<img width="783" alt="Screenshot 2021-01-30 at 02 22 51" src="https://user-images.githubusercontent.com/90802/106342720-5aa63c80-62a2-11eb-84b9-bfd4e8abdfbe.png">
