### PR TITLE
Allow to dynamically change the data subscription

### DIFF
--- a/packages/cache/src/Cache.js
+++ b/packages/cache/src/Cache.js
@@ -167,8 +167,8 @@ export class Cache {
       observer = Array.from(this._computedObservers).find(
         (o) =>
           o._compute === compute &&
-          o._inputs === inputs &&
-          o._isEqual === isEqual
+          o._isEqual === isEqual &&
+          shallowEqual(o._inputs, inputs)
       );
 
       if (observer) return observer;

--- a/packages/cache/src/Cache.js
+++ b/packages/cache/src/Cache.js
@@ -1,6 +1,6 @@
 import { Computed } from "./Computed.js";
 import { PathObserver } from "./PathObserver.js";
-import { shallowEqual } from "./equality.js";
+import { shallowEqual } from "@depository/shallow-equal";
 
 import {
   getIn,

--- a/packages/cache/src/Computed.spec.js
+++ b/packages/cache/src/Computed.spec.js
@@ -87,6 +87,29 @@ describe("cache.computed", () => {
     });
   });
 
+  describe("when observing similar computed that is already subscribed", () => {
+    it("returns the active observer", () => {
+      const compute = ({ a, b }) => a + b;
+
+      const sum = {
+        inputs: { a: "a", b: "b" },
+        compute,
+      };
+
+      const a = cache.observe(sum);
+      a.subscribe(spy);
+
+      const otherSum = {
+        inputs: { b: "b", a: "a" },
+        compute,
+      };
+
+      const b = cache.observe(otherSum);
+
+      expect(a, "to be", b);
+    });
+  });
+
   describe("when subscribed", () => {
     it("calculates the computed value", () => {
       sum.subscribe(spy);

--- a/packages/shallow-equal/package.json
+++ b/packages/shallow-equal/package.json
@@ -1,19 +1,16 @@
 {
   "type": "module",
-  "name": "@depository/cache",
-  "version": "0.26.0",
-  "description": "A reactive cache for @depository",
+  "name": "@depository/shallow-equal",
+  "version": "0.26.1",
+  "description": "Shallow equal",
   "module": "./src/index.js",
   "exports": {
     ".": "./src/index.js"
   },
   "sideEffects": false,
-  "scripts": {
-    "test": "mocha './src/**/*.spec.js'"
-  },
   "keywords": [
-    "cache",
-    "state"
+    "shallow",
+    "equal"
   ],
   "author": "Sune Simonsen <sune@we-knowhow.dk>",
   "license": "MIT",
@@ -24,16 +21,6 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@depository/path": "^0.26.0",
-    "@depository/shallow-equal": "^0.26.0"
-  },
-  "devDependencies": {
-    "mocha": "8.3.2",
-    "sinon": "^9.2.1",
-    "unexpected": "11.8.1",
-    "unexpected-sinon": "^11.0.1"
   },
   "engines": {
     "node": ">=12"

--- a/packages/shallow-equal/src/index.js
+++ b/packages/shallow-equal/src/index.js
@@ -1,3 +1,5 @@
+// Stolen from https://github.com/dashed/shallowequal
+
 export const shallowEqual = (objA, objB) => {
   if (objA === objB) {
     return true;

--- a/packages/view/src/vdom.js
+++ b/packages/view/src/vdom.js
@@ -131,16 +131,11 @@ class UserComponent {
     }
   }
 
-  _updateProps(props) {
-    this._props = props;
-    this._render();
-  }
+  _update(vdom) {
+    this._props = vdom._props;
+    this._children = vdom._children;
 
-  _updateChildren(children) {
-    if (this._children !== children) {
-      this._children = children;
-      this._render();
-    }
+    this._render();
   }
 
   _mount() {
@@ -291,7 +286,9 @@ class PrimitiveComponent {
     this._store = store;
   }
 
-  _updateProps(props) {
+  _update(vdom) {
+    const props = vdom._props;
+
     for (const p in this._props) {
       if (p !== "#" && p !== "ref" && !(p in props)) {
         const value = this._props[p];
@@ -333,9 +330,9 @@ class PrimitiveComponent {
     }
 
     this._props = props;
-  }
 
-  _updateChildren(children) {
+    const children = vdom._children;
+
     if (this._children !== children) {
       if (children === null) {
         unmount(this._children);
@@ -478,17 +475,16 @@ class PortalComponent extends Hidden {
     this._store = store;
   }
 
-  _updateProps({ target = document.body }) {
+  _update(vdom) {
+    const target = vdom._props.target || document.body;
     if (this._target !== target) {
       // Move DOM tree
       this._target = target;
       appendChildren(target, getDom(this._children));
     }
-  }
 
-  _updateChildren(children) {
     this._children = update(
-      children,
+      vdom._children,
       this._children,
       this._store,
       this._context,
@@ -693,8 +689,7 @@ export const update = (
   }
 
   if (updatedTree && updatedTree._type && updatedTree._type === vdom._type) {
-    vdom._updateProps(updatedTree._props);
-    vdom._updateChildren(updatedTree._children);
+    vdom._update(updatedTree);
     return vdom;
   }
 

--- a/packages/view/src/vdom.js
+++ b/packages/view/src/vdom.js
@@ -122,9 +122,7 @@ class UserComponent {
           this._isSvg
         );
 
-        if (instance.didUpdate) {
-          instance.didUpdate(prevProps);
-        }
+        instance.didUpdate && instance.didUpdate(prevProps);
       }
     } catch (e) {
       this._errorHandler(e);
@@ -132,8 +130,24 @@ class UserComponent {
   }
 
   _update(vdom) {
+    const instance = this._instance;
+
     this._props = vdom._props;
     this._children = vdom._children;
+
+    if (instance.data) {
+      const paths = instance.data(vdom._props);
+      const observable = this._store.observe(paths);
+      if (this._observable !== observable) {
+        this._subscription.unsubscribe();
+        this._observable = observable;
+        this._subscription = this._observable.subscribe((data) => {
+          this._data = data;
+          this._render();
+        });
+        this._data = this._observable.value;
+      }
+    }
 
     this._render();
   }
@@ -180,7 +194,7 @@ class UserComponent {
 
       const dom = mount(this._vdom);
 
-      instance.didMount && this._instance.didMount();
+      instance.didMount && instance.didMount();
 
       mounting = false;
 

--- a/packages/view/src/vdom.js
+++ b/packages/view/src/vdom.js
@@ -82,10 +82,6 @@ class UserComponent {
     instance.dispatch = store.dispatch.bind(store);
     instance.props = instanceProps;
     instance.shouldUpdate = instance.shouldUpdate || defaultShouldUpdate;
-    const paths = instance.data && instance.data(instanceProps);
-    if (paths) {
-      this._observable = store.observe(paths);
-    }
   }
 
   get _dom() {
@@ -151,12 +147,13 @@ class UserComponent {
     try {
       let mounting = true;
       const instance = this._instance;
+      instance.props = this._createInstanceProps();
 
-      if (this._observable) {
+      if (instance.data) {
+        const paths = instance.data(instance.props);
+        this._observable = this._store.observe(paths);
         this._data = this._observable.value;
       }
-
-      instance.props = this._createInstanceProps();
 
       instance.willMount && instance.willMount();
 


### PR DESCRIPTION
Only allowing a component to specify its data subscription based on props is not really enough. Especially when having the routing information in the store it is useful that we resubscribe to the updated paths return by `data`.