### PR TITLE
Remove need for mapping props (Major)

### DIFF
--- a/docs/components/public/pages/anchor/index.js
+++ b/docs/components/public/pages/anchor/index.js
@@ -20,8 +20,9 @@ class AnchorPage {
       <${Heading} level="2">How to use it<//>
       <${Heading} level="3">Default<//>
       <p>
-        The Anchor component is a styled<code class="inline">${"<a>"}</code>tag.
-        It accepts all standard anchor attributes and signals a way to navigate.
+        The Anchor component is a styled<code className="inline">${"<a>"}</code
+        >tag. It accepts all standard anchor attributes and signals a way to
+        navigate.
       </p>
       <${Example} src=${new URL("./DefaultAnchor.js", import.meta.url)}>
         <${DefaultAnchor} />

--- a/docs/components/public/pages/borderlayout/DefaultBorderLayout.js
+++ b/docs/components/public/pages/borderlayout/DefaultBorderLayout.js
@@ -15,11 +15,11 @@ export default class Example {
   render() {
     return html`
       <${BorderLayout}>
-        <div class=${areaStyles("top", "#5eae91")}>Top</div>
-        <div class=${areaStyles("start", "#ffb057")}>Start</div>
-        <div class=${areaStyles("main", "#daeded")}>Main</div>
-        <div class=${areaStyles("end", "#ffb057")}>End</div>
-        <div class=${areaStyles("bottom", "#5eae91")}>Bottom</div>
+        <div className=${areaStyles("top", "#5eae91")}>Top</div>
+        <div className=${areaStyles("start", "#ffb057")}>Start</div>
+        <div className=${areaStyles("main", "#daeded")}>Main</div>
+        <div className=${areaStyles("end", "#ffb057")}>End</div>
+        <div className=${areaStyles("bottom", "#5eae91")}>Bottom</div>
       <//>
     `;
   }

--- a/docs/components/public/pages/borderlayout/OmitAreas.js
+++ b/docs/components/public/pages/borderlayout/OmitAreas.js
@@ -16,36 +16,36 @@ export default class Example {
     return html`
       <${ColumnLayout} columns="2" stretched>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("top", "#5eae91")}>Top</div>
-          <div class=${areaStyles("start", "#ffb057")}>Start</div>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
-          <div class=${areaStyles("bottom", "#5eae91")}>Bottom</div>
+          <div className=${areaStyles("top", "#5eae91")}>Top</div>
+          <div className=${areaStyles("start", "#ffb057")}>Start</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("bottom", "#5eae91")}>Bottom</div>
         <//>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("top", "#5eae91")}>Top</div>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
-          <div class=${areaStyles("end", "#ffb057")}>End</div>
-          <div class=${areaStyles("bottom", "#5eae91")}>Bottom</div>
+          <div className=${areaStyles("top", "#5eae91")}>Top</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("end", "#ffb057")}>End</div>
+          <div className=${areaStyles("bottom", "#5eae91")}>Bottom</div>
         <//>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("top", "#5eae91")}>Top</div>
-          <div class=${areaStyles("start", "#ffb057")}>Start</div>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
-          <div class=${areaStyles("end", "#ffb057")}>End</div>
+          <div className=${areaStyles("top", "#5eae91")}>Top</div>
+          <div className=${areaStyles("start", "#ffb057")}>Start</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("end", "#ffb057")}>End</div>
         <//>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("start", "#ffb057")}>Start</div>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
-          <div class=${areaStyles("end", "#ffb057")}>End</div>
-          <div class=${areaStyles("bottom", "#5eae91")}>Bottom</div>
+          <div className=${areaStyles("start", "#ffb057")}>Start</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("end", "#ffb057")}>End</div>
+          <div className=${areaStyles("bottom", "#5eae91")}>Bottom</div>
         <//>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("start", "#ffb057")}>Start</div>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("start", "#ffb057")}>Start</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
         <//>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
-          <div class=${areaStyles("end", "#ffb057")}>End</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("end", "#ffb057")}>End</div>
         <//>
       <//>
     `;

--- a/docs/components/public/pages/borderlayout/Stretched.js
+++ b/docs/components/public/pages/borderlayout/Stretched.js
@@ -20,13 +20,13 @@ const areaStyles = (area, color) => css`
 export default class Example {
   render() {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${BorderLayout} stretched>
-          <div class=${areaStyles("top", "#5eae91")}>Top</div>
-          <div class=${areaStyles("start", "#ffb057")}>Start</div>
-          <div class=${areaStyles("main", "#daeded")}>Main</div>
-          <div class=${areaStyles("end", "#ffb057")}>End</div>
-          <div class=${areaStyles("bottom", "#5eae91")}>Bottom</div>
+          <div className=${areaStyles("top", "#5eae91")}>Top</div>
+          <div className=${areaStyles("start", "#ffb057")}>Start</div>
+          <div className=${areaStyles("main", "#daeded")}>Main</div>
+          <div className=${areaStyles("end", "#ffb057")}>End</div>
+          <div className=${areaStyles("bottom", "#5eae91")}>Bottom</div>
         <//>
       </div>
     `;

--- a/docs/components/public/pages/button/DefaultButton.js
+++ b/docs/components/public/pages/button/DefaultButton.js
@@ -9,6 +9,6 @@ export default class Example {
   }
 
   render() {
-    return html`<${Center}><${Button} @click=${this.sayHello}>Button<//><//>`;
+    return html`<${Center}><${Button} onClick=${this.sayHello}>Button<//><//>`;
   }
 }

--- a/docs/components/public/pages/button/DisabledButton.js
+++ b/docs/components/public/pages/button/DisabledButton.js
@@ -10,7 +10,7 @@ export default class Example {
 
   render() {
     return html`
-      <${Center}><${Button} @click=${this.sayHello} disabled>Button<//><//>
+      <${Center}><${Button} onClick=${this.sayHello} disabled>Button<//><//>
     `;
   }
 }

--- a/docs/components/public/pages/button/LoadingButton.js
+++ b/docs/components/public/pages/button/LoadingButton.js
@@ -25,7 +25,7 @@ export default class Example {
   render({ loading }) {
     return html`
       <${Center}>
-        <${Button} loading=${loading} @click=${this.startLoading}>Button<//>
+        <${Button} loading=${loading} onClick=${this.startLoading}>Button<//>
       <//>
     `;
   }

--- a/docs/components/public/pages/button/MediaButton.js
+++ b/docs/components/public/pages/button/MediaButton.js
@@ -9,12 +9,12 @@ export default class Example {
       <${Center}>
         <${ColumnLayout} columns="auto auto">
           <${Button}>
-            <${LifesaverStroke16Icon} class=${me2} />
+            <${LifesaverStroke16Icon} className=${me2} />
             Get Help
           <//>
           <${Button}>
             Menu
-            <${ChevronDownStroke12Icon} class=${ms1} />
+            <${ChevronDownStroke12Icon} className=${ms1} />
           <//>
         <//>
       <//>

--- a/docs/components/public/pages/center/Stretched.js
+++ b/docs/components/public/pages/center/Stretched.js
@@ -15,8 +15,8 @@ export default class Example {
   render() {
     return html`
       <${ColumnLayout} columns="2" stretched>
-        <${Center} class=${containerStyles}>Not stretched<//>
-        <${Center} stretched class=${containerStyles}>Stretched<//>
+        <${Center} className=${containerStyles}>Not stretched<//>
+        <${Center} stretched className=${containerStyles}>Stretched<//>
       <//>
     `;
   }

--- a/docs/components/public/pages/checkbox/DefaultCheckbox.js
+++ b/docs/components/public/pages/checkbox/DefaultCheckbox.js
@@ -38,7 +38,7 @@ class IngredientCheckbox {
       <${Checkbox}
         id=${id}
         .checked=${checked}
-        @change=${this.updateIngredient}
+        onChange=${this.updateIngredient}
       />
       <label for=${id}>${id}</label>
     `;

--- a/docs/components/public/pages/columnlayout/index.js
+++ b/docs/components/public/pages/columnlayout/index.js
@@ -25,7 +25,7 @@ class ColumnLayoutPage {
       <${Heading} level="3">Default<//>
       <p>
         The column layout uses one column by default with a gap of
-        <code class="inline">1em</code>.
+        <code className="inline">1em</code>.
       </p>
       <${Example} src=${new URL("./DefaultColumnLayout.js", import.meta.url)}>
         <${DefaultColumnLayout} />
@@ -33,7 +33,7 @@ class ColumnLayoutPage {
       <${Heading} level="3">Columns<//>
       <p>
         The number of columns can be specified using the
-        <code class="inline">columns</code> property.
+        <code className="inline">columns</code> property.
       </p>
       <${Example} src=${new URL("./NumberOfColumns.js", import.meta.url)}>
         <${NumberOfColumns} />
@@ -54,16 +54,16 @@ class ColumnLayoutPage {
       <${Heading} level="3">Gap<//>
       <p>
         Control the gap between the children with the
-        <code class="inline">gap</code> property.
+        <code className="inline">gap</code> property.
       </p>
       <${Example} src=${new URL("./Gap.js", import.meta.url)}>
         <${Gap} />
       <//>
       <${Heading} level="3">Align items<//>
       <p>
-        You can control <code class="inline">align-items</code> using the
-        <code class="inline">alignItems</code> property. The default value is
-        <code class="inline">center</code>.
+        You can control <code className="inline">align-items</code> using the
+        <code className="inline">alignItems</code> property. The default value
+        is <code className="inline">center</code>.
       </p>
       <${Example} src=${new URL("./AlignItems.js", import.meta.url)}>
         <${AlignItems} />
@@ -71,9 +71,9 @@ class ColumnLayoutPage {
       <${Heading} level="3">Justify items<//>
       <p>
         Similarly you can control
-        <code class="inline">justify-items</code> using the
-        <code class="inline">justifyItems</code> property. The default value is
-        <code class="inline">center</code>.
+        <code className="inline">justify-items</code> using the
+        <code className="inline">justifyItems</code> property. The default value
+        is <code className="inline">center</code>.
       </p>
       <${Example} src=${new URL("./JustifyItems.js", import.meta.url)}>
         <${JustifyItems} />

--- a/docs/components/public/pages/icons/IconColors.js
+++ b/docs/components/public/pages/icons/IconColors.js
@@ -15,7 +15,7 @@ export default class Example {
   render() {
     return html`
       <${Center}>
-        <${AnswerBot26Icon} class=${answerBotStyles} />
+        <${AnswerBot26Icon} className=${answerBotStyles} />
       <//>
     `;
   }

--- a/docs/components/public/pages/icons/IconUsage.js
+++ b/docs/components/public/pages/icons/IconUsage.js
@@ -18,8 +18,8 @@ export default class Example {
         <${ColumnLayout} columns="2">
           <${StarStroke16Icon} />
           <${StarFill16Icon} />
-          <${StarStroke16Icon} class=${redStyles} />
-          <${StarFill16Icon} class=${redStyles} />
+          <${StarStroke16Icon} className=${redStyles} />
+          <${StarFill16Icon} className=${redStyles} />
         <//>
       <//>
     `;

--- a/docs/components/public/pages/icons/index.js
+++ b/docs/components/public/pages/icons/index.js
@@ -964,7 +964,11 @@ class IconCopyButton {
 
   render({ children }) {
     return html`
-      <button onClick=${this.onClick} class=${copyStyles} title="Click to copy">
+      <button
+        onClick=${this.onClick}
+        className=${copyStyles}
+        title="Click to copy"
+      >
         ${children}
       </button>
     `;
@@ -987,9 +991,9 @@ class IconsPage {
       <p>
         The icons come in two flavors – monochrome and two-tone. The primary
         fill/stroke will always be specified as
-        <code class="inline">currentColor</code> This means CSS text color style
-        will cascade to the icon. Two-tone icons can receive a secondary color
-        via the <code class="inline">fill</code> style property.
+        <code className="inline">currentColor</code> This means CSS text color
+        style will cascade to the icon. Two-tone icons can receive a secondary
+        color via the <code className="inline">fill</code> style property.
       </p>
       <${Example} src=${new URL("./IconUsage.js", import.meta.url)}>
         <${IconUsage} />
@@ -1006,14 +1010,14 @@ class IconsPage {
         import to that clipboard.
       </p>
       <${Heading} level="2">12px icons<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${Grip12Icon} />
         <${IconCopyButton}>Grip12Icon<//>
         <${Paperclip12Icon} />
         <${IconCopyButton}>Paperclip12Icon<//>
       </div>
       <${Heading} level="2">12px icons (fill)<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${I123Fill12Icon} />
         <${IconCopyButton}>I123Fill12Icon<//>
         <${AdjustFill12Icon} />
@@ -1424,7 +1428,7 @@ class IconsPage {
         <${IconCopyButton}>ZendeskFill12Icon<//>
       </div>
       <${Heading} level="2">12px icons (stroke)<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${I123Stroke12Icon} />
         <${IconCopyButton}>I123Stroke12Icon<//>
         <${AdjustStroke12Icon} />
@@ -1835,14 +1839,14 @@ class IconsPage {
         <${IconCopyButton}>ZendeskStroke12Icon<//>
       </div>
       <${Heading} level="2">16px icons<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${Grip16Icon} />
         <${IconCopyButton}>Grip16Icon<//>
         <${Paperclip16Icon} />
         <${IconCopyButton}>Paperclip16Icon<//>
       </div>
       <${Heading} level="2">16px icons (fill)<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${I123Fill16Icon} />
         <${IconCopyButton}>I123Fill16Icon<//>
         <${AdjustFill16Icon} />
@@ -2253,7 +2257,7 @@ class IconsPage {
         <${IconCopyButton}>ZendeskFill16Icon<//>
       </div>
       <${Heading} level="2">16px icons (stroke)<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${I123Stroke16Icon} />
         <${IconCopyButton}>I123Stroke16Icon<//>
         <${AdjustStroke16Icon} />
@@ -2664,7 +2668,7 @@ class IconsPage {
         <${IconCopyButton}>ZendeskStroke16Icon<//>
       </div>
       <${Heading} level="2">26px icons<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${AnswerBot26Icon} />
         <${IconCopyButton}>AnswerBot26Icon<//>
         <${App26Icon} />
@@ -2781,7 +2785,7 @@ class IconsPage {
         <${IconCopyButton}>Zendesk26Icon<//>
       </div>
       <${Heading} level="2">26px icons (fill)<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${CustomerListsFill26Icon} />
         <${IconCopyButton}>CustomerListsFill26Icon<//>
         <${EmailFill26Icon} />
@@ -2796,7 +2800,7 @@ class IconsPage {
         <${IconCopyButton}>ViewsFill26Icon<//>
       </div>
       <${Heading} level="2">26px icons (wordmark)<//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
         <${WordmarkBoldSuite26Icon} />
         <${IconCopyButton}>WordmarkBoldSuite26Icon<//>
         <${WordmarkBoldSupport26Icon} />

--- a/docs/components/public/pages/icons/index.js
+++ b/docs/components/public/pages/icons/index.js
@@ -964,7 +964,7 @@ class IconCopyButton {
 
   render({ children }) {
     return html`
-      <button @click=${this.onClick} class=${copyStyles} title="Click to copy">
+      <button onClick=${this.onClick} class=${copyStyles} title="Click to copy">
         ${children}
       </button>
     `;

--- a/docs/components/public/pages/menu/DefaultMenu.js
+++ b/docs/components/public/pages/menu/DefaultMenu.js
@@ -24,7 +24,7 @@ export default class Example {
   render({ id }) {
     return html`
       <div class=${containerStyles}>
-        <${Menu} id=${id} @selectItem=${this.onSelect}>
+        <${Menu} id=${id} onSelectItem=${this.onSelect}>
           <${MenuButton}>Options<//>
           <${MenuPopup}>
             <${MenuItem} id=${id} key="one" value=${1}>One<//>

--- a/docs/components/public/pages/menu/DefaultMenu.js
+++ b/docs/components/public/pages/menu/DefaultMenu.js
@@ -23,7 +23,7 @@ export default class Example {
 
   render({ id }) {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${Menu} id=${id} onSelectItem=${this.onSelect}>
           <${MenuButton}>Options<//>
           <${MenuPopup}>

--- a/docs/components/public/pages/menu/Flexibility.js
+++ b/docs/components/public/pages/menu/Flexibility.js
@@ -93,8 +93,8 @@ class CustomMenuItem {
     return html`
       <button
         tabindex="-1"
-        @mousedown=${this.onMouseDown}
-        @mouseenter=${this.onMouseEnter}
+        onMouseDown=${this.onMouseDown}
+        onMouseEnter=${this.onMouseEnter}
         class=${classes(
           menuItemStyles(color),
           selected && focusedMenuItemStyles
@@ -128,7 +128,7 @@ export default class Example {
   render({ id }) {
     return html`
       <div class=${containerStyles}>
-        <${Menu} id=${id} placement="bottom" @selectItem=${this.onSelect}>
+        <${Menu} id=${id} placement="bottom" onSelectItem=${this.onSelect}>
           <${CustomMenuButton}>Menu<//>
           <${CustomMenuPopup}>
             <${ColumnLayout} gap="0" stretched columns="2">

--- a/docs/components/public/pages/menu/Flexibility.js
+++ b/docs/components/public/pages/menu/Flexibility.js
@@ -23,9 +23,9 @@ const menuButtonStyles = css`
 `;
 
 class CustomMenuButton {
-  render({ children, class: className, ...other }) {
+  render({ children, className, ...other }) {
     return html`
-      <button class=${classes(menuButtonStyles, className)} ...${other}>
+      <button className=${classes(menuButtonStyles, className)} ...${other}>
         ${children}
       </button>
     `;
@@ -40,9 +40,9 @@ const popupStyles = css`
 `;
 
 class CustomMenuPopup {
-  render({ children, class: className, ...other }) {
+  render({ children, className, ...other }) {
     return html`
-      <div class=${classes(popupStyles, className)} ...${other}>
+      <div className=${classes(popupStyles, className)} ...${other}>
         ${children}
       </div>
     `;
@@ -95,7 +95,7 @@ class CustomMenuItem {
         tabindex="-1"
         onMouseDown=${this.onMouseDown}
         onMouseEnter=${this.onMouseEnter}
-        class=${classes(
+        className=${classes(
           menuItemStyles(color),
           selected && focusedMenuItemStyles
         )}
@@ -127,7 +127,7 @@ export default class Example {
 
   render({ id }) {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${Menu} id=${id} placement="bottom" onSelectItem=${this.onSelect}>
           <${CustomMenuButton}>Menu<//>
           <${CustomMenuPopup}>

--- a/docs/components/public/pages/menu/NestedMenu.js
+++ b/docs/components/public/pages/menu/NestedMenu.js
@@ -67,7 +67,7 @@ export default class Example {
 
   render({ menu = "root" }) {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${NestedMenu}
           id=${id}
           placement="end"

--- a/docs/components/public/pages/menu/NestedMenu.js
+++ b/docs/components/public/pages/menu/NestedMenu.js
@@ -71,9 +71,9 @@ export default class Example {
         <${NestedMenu}
           id=${id}
           placement="end"
-          @menuChanged=${this.onMenuChanged}
-          @hide=${this.onHide}
-          @selectItem=${this.onSelect}
+          onMenuChanged=${this.onMenuChanged}
+          onHide=${this.onHide}
+          onSelectItem=${this.onSelect}
         >
           <${MenuButton}>Fruit<//>
           <${MenuPopup}>${menus[menu]}<//>

--- a/docs/components/public/pages/menu/Placement.js
+++ b/docs/components/public/pages/menu/Placement.js
@@ -16,7 +16,7 @@ export default class Example {
 
   render({ id }) {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${Menu} id=${id} placement="top-start">
           <${MenuButton}>Options<//>
           <${MenuPopup}>

--- a/docs/components/public/pages/menu/index.js
+++ b/docs/components/public/pages/menu/index.js
@@ -41,8 +41,8 @@ class AnchorPage {
       <p>
         Menu placement can be oriented around a trigger element in different
         positions. The default placement is
-        <code class="inline">bottom-start</code>. This example demonstrates the
-        <code class="inline">top-start</code> placement.
+        <code className="inline">bottom-start</code>. This example demonstrates
+        the <code className="inline">top-start</code> placement.
       </p>
       <${Example} src=${new URL("./Placement.js", import.meta.url)}>
         <${Placement} />

--- a/docs/components/public/pages/popup/DefaultPopup.js
+++ b/docs/components/public/pages/popup/DefaultPopup.js
@@ -31,9 +31,9 @@ export default class Example {
 
   render() {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${Button} ref=${this.createRef("anchorRef")}>Anchor<//>
-        <div ref=${this.createRef("popupRef")} class=${popupStyles}>
+        <div ref=${this.createRef("popupRef")} className=${popupStyles}>
           Popup content
         </div>
       </div>

--- a/docs/components/public/pages/popup/Margins.js
+++ b/docs/components/public/pages/popup/Margins.js
@@ -31,9 +31,9 @@ export default class Example {
 
   render() {
     return html`
-      <div class=${containerStyles}>
+      <div className=${containerStyles}>
         <${Button} ref=${this.createRef("anchorRef")}>Anchor<//>
-        <div ref=${this.createRef("popupRef")} class=${popupStyles}>
+        <div ref=${this.createRef("popupRef")} className=${popupStyles}>
           Popup content
         </div>
       </div>

--- a/docs/components/public/pages/popup/Placement.js
+++ b/docs/components/public/pages/popup/Placement.js
@@ -72,7 +72,7 @@ export default class Example {
           <div
             key="{placement}"
             ref=${this.createRef(`${placement}-popup-ref`)}
-            class=${popupStyles}
+            className=${popupStyles}
           >
             ${placement}
           </div>
@@ -82,8 +82,8 @@ export default class Example {
 
   render() {
     return html`
-      <${Center} class=${containerStyles}>
-        <${Center} class=${anchorStyles} ref=${this.createRef("anchorRef")}>
+      <${Center} className=${containerStyles}>
+        <${Center} className=${anchorStyles} ref=${this.createRef("anchorRef")}>
           Anchor
         <//>
         ${this.popupElements()}

--- a/docs/components/public/pages/popup/PopupFlip.js
+++ b/docs/components/public/pages/popup/PopupFlip.js
@@ -34,7 +34,7 @@ export default class Example {
 
   render() {
     return html`
-      <${ScrollArea} class=${containerStyles}>
+      <${ScrollArea} className=${containerStyles}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
           placerat nulla molestie eros elementum, id aliquam augue pretium.
@@ -53,7 +53,7 @@ export default class Example {
           interdum at. Duis cursus non ipsum tincidunt rhoncus.
         </p>
         <${Button} ref=${this.createRef("anchorRef")}>Anchor<//>
-        <div ref=${this.createRef("popupRef")} class=${popupStyles}>
+        <div ref=${this.createRef("popupRef")} className=${popupStyles}>
           Popup content
         </div>
         <p>

--- a/docs/components/public/pages/popup/Stretch.js
+++ b/docs/components/public/pages/popup/Stretch.js
@@ -59,7 +59,7 @@ export default class Example {
           <div
             key="{placement}"
             ref=${this.createRef(`${placement}-popup-ref`)}
-            class=${popupStyles}
+            className=${popupStyles}
           >
             ${placement}
           </div>
@@ -69,8 +69,8 @@ export default class Example {
 
   render() {
     return html`
-      <${Center} class=${containerStyles}>
-        <${Center} class=${anchorStyles} ref=${this.createRef("anchorRef")}>
+      <${Center} className=${containerStyles}>
+        <${Center} className=${anchorStyles} ref=${this.createRef("anchorRef")}>
           Anchor
         <//>
         ${this.popupElements()}

--- a/docs/components/public/pages/select/DefaultSelect.js
+++ b/docs/components/public/pages/select/DefaultSelect.js
@@ -51,7 +51,7 @@ export default class Example {
 
   render({ selected }) {
     return html`
-      <${Center} class=${containerStyles}>
+      <${Center} className=${containerStyles}>
         <${ColumnLayout} columns="auto 300px">
           <label for=${id}>Brand</label>
           <${Select} id=${id} onSelectItem=${this.onSelect}>

--- a/docs/components/public/pages/select/DefaultSelect.js
+++ b/docs/components/public/pages/select/DefaultSelect.js
@@ -54,7 +54,7 @@ export default class Example {
       <${Center} class=${containerStyles}>
         <${ColumnLayout} columns="auto 300px">
           <label for=${id}>Brand</label>
-          <${Select} id=${id} @selectItem=${this.onSelect}>
+          <${Select} id=${id} onSelectItem=${this.onSelect}>
             <${SelectInput} .value=${labels[selected]}>${labels[selected]}<//>
             <${SelectPopup}>
               ${options.map(

--- a/docs/components/public/pages/select/Disabled.js
+++ b/docs/components/public/pages/select/Disabled.js
@@ -48,7 +48,7 @@ export default class Example {
       <${Center}>
         <${ColumnLayout} columns="auto 300px">
           <label for=${id}>Brand</label>
-          <${Select} id=${id} @selectItem=${this.onSelect}>
+          <${Select} id=${id} onSelectItem=${this.onSelect}>
             <${SelectInput} disabled .value=${labels[selected]}>
               ${labels[selected]}
             <//>

--- a/docs/components/public/pages/select/NestedSelect.js
+++ b/docs/components/public/pages/select/NestedSelect.js
@@ -115,9 +115,9 @@ export default class Example {
           <label for=${id}>Fruit</label>
           <${NestedSelect}
             id=${id}
-            @menuChanged=${this.onMenuChanged}
-            @hide=${this.onHide}
-            @selectItem=${this.onSelect}
+            onMenuChanged=${this.onMenuChanged}
+            onHide=${this.onHide}
+            onSelectItem=${this.onSelect}
           >
             <${SelectInput} .value=${fruits[selected].label}>
               ${fruits[selected].label}

--- a/docs/components/public/pages/select/NestedSelect.js
+++ b/docs/components/public/pages/select/NestedSelect.js
@@ -110,7 +110,7 @@ export default class Example {
 
   render({ menu = "root", selected }) {
     return html`
-      <${Center} class=${containerStyles}>
+      <${Center} className=${containerStyles}>
         <${ColumnLayout} columns="auto 300px">
           <label for=${id}>Fruit</label>
           <${NestedSelect}

--- a/docs/components/public/pages/spinner/Flexibility.js
+++ b/docs/components/public/pages/spinner/Flexibility.js
@@ -39,10 +39,10 @@ export default class Example {
     return html`
       <${Center}>
         <${ColumnLayout} columns="auto auto auto auto" >
-          <${Spinner} class=${firstSpinner} />
-          <${Spinner} class=${secondSpinner} />
-          <${Spinner} class=${thirdSpinner}/>
-          <${Spinner} class=${fourthSpinner}/>
+          <${Spinner} className=${firstSpinner} />
+          <${Spinner} className=${secondSpinner} />
+          <${Spinner} className=${thirdSpinner}/>
+          <${Spinner} className=${fourthSpinner}/>
         <//>
       <//
     `;

--- a/docs/components/public/pages/switch/DefaultSwitch.js
+++ b/docs/components/public/pages/switch/DefaultSwitch.js
@@ -17,7 +17,7 @@ class DaylightIcon {
 
   render({ isDay }) {
     const icon = isDay ? "🌔" : "🌘";
-    return html`<span class=${iconStyles}>${icon}</span>`;
+    return html`<span className=${iconStyles}>${icon}</span>`;
   }
 }
 

--- a/docs/components/public/pages/switch/DefaultSwitch.js
+++ b/docs/components/public/pages/switch/DefaultSwitch.js
@@ -40,7 +40,7 @@ export default class Example {
     return html`
       <${Center}>
         <${ColumnLayout} columns="2">
-          <${Switch} id="switch" .checked=${isDay} @change=${this.toggleDay} />
+          <${Switch} id="switch" .checked=${isDay} onChange=${this.toggleDay} />
           <${DaylightIcon} />
         <//>
       <//>

--- a/docs/components/public/pages/textinput/DefaultInput.js
+++ b/docs/components/public/pages/textinput/DefaultInput.js
@@ -38,9 +38,9 @@ export default class Example {
             id="car-model"
             type="text"
             .value=${value}
-            @change=${this.onChange}
+            onChange=${this.onChange}
           />
-          <${Button} @click=${this.onSubmit}>Submit<//>
+          <${Button} onClick=${this.onSubmit}>Submit<//>
         <//>
       <//>
     `;

--- a/docs/components/public/pages/textinput/DisabledInput.js
+++ b/docs/components/public/pages/textinput/DisabledInput.js
@@ -39,9 +39,9 @@ export default class Example {
             type="text"
             .value=${value}
             disabled
-            @change=${this.onChange}
+            onChange=${this.onChange}
           />
-          <${Button} @click=${this.onSubmit}>Submit<//>
+          <${Button} onClick=${this.onSubmit}>Submit<//>
         <//>
       <//>
     `;

--- a/docs/components/public/pages/textinput/MediaInput.js
+++ b/docs/components/public/pages/textinput/MediaInput.js
@@ -45,11 +45,11 @@ export default class Example {
               id="car-brand"
               type="text"
               .value=${value}
-              @change=${this.onChange}
+              onChange=${this.onChange}
             />
             <${SearchStroke16Icon} class=${ms2} />
           <//>
-          <${Button} @click=${this.onSubmit}>Search<//>
+          <${Button} onClick=${this.onSubmit}>Search<//>
         <//>
       <//>
     `;

--- a/docs/components/public/pages/textinput/MediaInput.js
+++ b/docs/components/public/pages/textinput/MediaInput.js
@@ -40,14 +40,14 @@ export default class Example {
         <${ColumnLayout} columns="auto 300px auto">
           <label for="car-brand">Find brand</label>
           <${MediaInput}>
-            <${CarStroke12Icon} class=${me2} />
+            <${CarStroke12Icon} className=${me2} />
             <input
               id="car-brand"
               type="text"
               .value=${value}
               onChange=${this.onChange}
             />
-            <${SearchStroke16Icon} class=${ms2} />
+            <${SearchStroke16Icon} className=${ms2} />
           <//>
           <${Button} onClick=${this.onSubmit}>Search<//>
         <//>

--- a/docs/components/public/pages/textinput/ReadonlyInput.js
+++ b/docs/components/public/pages/textinput/ReadonlyInput.js
@@ -39,9 +39,9 @@ export default class Example {
             type="text"
             readonly
             .value=${value}
-            @change=${this.onChange}
+            onChange=${this.onChange}
           />
-          <${Button} @click=${this.onSubmit}>Submit<//>
+          <${Button} onClick=${this.onSubmit}>Submit<//>
         <//>
       <//>
     `;

--- a/examples/hackernews/public/components/Answers.js
+++ b/examples/hackernews/public/components/Answers.js
@@ -26,7 +26,7 @@ export class Answers {
     );
 
     return html`
-      <ul class=${styles}>
+      <ul className=${styles}>
         ${answers}
       </ul>
     `;

--- a/examples/hackernews/public/components/Byline.js
+++ b/examples/hackernews/public/components/Byline.js
@@ -38,7 +38,7 @@ export class Byline {
 
   render({ id, story }) {
     return html`
-      <div class=${styles}>
+      <div className=${styles}>
         <span>${story.score} points by ${story.by}</span>
         <span>${formatRelativeHours(story.time)}</span>
         <${CommentsLink} id=${id} />

--- a/examples/hackernews/public/components/CloseAnswers.js
+++ b/examples/hackernews/public/components/CloseAnswers.js
@@ -18,6 +18,6 @@ export class CloseAnswers {
   }
 
   render() {
-    return html`<${CloseButton} @click=${this.onClick} />`;
+    return html`<${CloseButton} onClick=${this.onClick} />`;
   }
 }

--- a/examples/hackernews/public/components/CloseButton.js
+++ b/examples/hackernews/public/components/CloseButton.js
@@ -21,6 +21,6 @@ const styles = css`
 
 export class CloseButton {
   render(props) {
-    return html` <button class=${styles} ...${props}>X</button> `;
+    return html` <button className=${styles} ...${props}>X</button> `;
   }
 }

--- a/examples/hackernews/public/components/CloseComments.js
+++ b/examples/hackernews/public/components/CloseComments.js
@@ -12,6 +12,6 @@ export class CloseComments {
   }
 
   render() {
-    return html`<${CloseButton} @click=${this.onClick} />`;
+    return html`<${CloseButton} onClick=${this.onClick} />`;
   }
 }

--- a/examples/hackernews/public/components/Comment.js
+++ b/examples/hackernews/public/components/Comment.js
@@ -72,7 +72,7 @@ export class Comment {
     if (!status) this.dispatch(loadComment(id));
     if (status !== "ready")
       return html`
-        <li class=${styles}>
+        <li className=${styles}>
           <div><${Skeleton} /></div>
           <div><${Skeleton} /></div>
           <div><${Skeleton} /></div>
@@ -82,11 +82,11 @@ export class Comment {
     if (!comment) return null;
 
     return html`
-      <li class=${styles}>
+      <li className=${styles}>
         <div>
           <${Html}>${comment.text}<//>
         </div>
-        <div class=${bylineStyles}>
+        <div className=${bylineStyles}>
           <span>by ${comment.by}</span>
           <span>${formatRelativeHours(comment.time)}</span>
           ${showAnswersLink &&

--- a/examples/hackernews/public/components/CommentAndAnswers.js
+++ b/examples/hackernews/public/components/CommentAndAnswers.js
@@ -37,10 +37,10 @@ export class CommentAndAnswers {
 
   render({ id }) {
     return html`
-      <div class=${containerStyles}>
-        <div class=${itemStyles}>
+      <div className=${containerStyles}>
+        <div className=${itemStyles}>
           <${Comment} id=${id} />
-          <div class=${answerStyles}>
+          <div className=${answerStyles}>
             <${Answers} id=${id} />
           </div>
           <${CloseAnswers} />

--- a/examples/hackernews/public/components/Comments.js
+++ b/examples/hackernews/public/components/Comments.js
@@ -23,7 +23,7 @@ export class Comments {
     );
 
     return html`
-      <ul class=${styles}>
+      <ul className=${styles}>
         ${comments}
       </ul>
     `;

--- a/examples/hackernews/public/components/DefaultLayout.js
+++ b/examples/hackernews/public/components/DefaultLayout.js
@@ -25,7 +25,9 @@ export class DefaultLayout {
     return html`
       <main>
         <${TopBar} />
-        <section ref=${this.setContentRef} class="content">${children}</section>
+        <section ref=${this.setContentRef} className="content">
+          ${children}
+        </section>
       </main>
     `;
   }

--- a/examples/hackernews/public/components/Details.js
+++ b/examples/hackernews/public/components/Details.js
@@ -13,7 +13,7 @@ const detailsStyles = css`
 export class Details {
   render({ id }) {
     return html`
-      <div class=${detailsStyles}>
+      <div className=${detailsStyles}>
         <${Comments} id=${id} />
         <${CloseComments} id=${id} />
       </div>

--- a/examples/hackernews/public/components/LinkButton.js
+++ b/examples/hackernews/public/components/LinkButton.js
@@ -16,6 +16,6 @@ const styles = css`
 
 export class LinkButton {
   render({ children, ...other }) {
-    return html`<${Link} class=${styles} ...${other}>${children}<//>`;
+    return html`<${Link} className=${styles} ...${other}>${children}<//>`;
   }
 }

--- a/examples/hackernews/public/components/ReloadButton.js
+++ b/examples/hackernews/public/components/ReloadButton.js
@@ -57,7 +57,7 @@ export class ReloadButton {
 
   render({ status }) {
     return html`
-      <button @click=${this.reload} class=${reloadStyles} title="refresh">
+      <button onClick=${this.reload} class=${reloadStyles} title="refresh">
         <${ReloadIcon} class=${status === "loading" && loadingStyles} />
       </button>
     `;

--- a/examples/hackernews/public/components/ReloadButton.js
+++ b/examples/hackernews/public/components/ReloadButton.js
@@ -57,8 +57,8 @@ export class ReloadButton {
 
   render({ status }) {
     return html`
-      <button onClick=${this.reload} class=${reloadStyles} title="refresh">
-        <${ReloadIcon} class=${status === "loading" && loadingStyles} />
+      <button onClick=${this.reload} className=${reloadStyles} title="refresh">
+        <${ReloadIcon} className=${status === "loading" && loadingStyles} />
       </button>
     `;
   }

--- a/examples/hackernews/public/components/Skeleton.js
+++ b/examples/hackernews/public/components/Skeleton.js
@@ -17,6 +17,6 @@ const styles = css`
 export class Skeleton {
   render() {
     const width = `${Math.random() * 100 + 500}px`;
-    return html` <div class=${styles} style=${{ width }} /> `;
+    return html` <div className=${styles} style=${{ width }} /> `;
   }
 }

--- a/examples/hackernews/public/components/Stories.js
+++ b/examples/hackernews/public/components/Stories.js
@@ -70,14 +70,14 @@ export class Stories {
     if (status !== "ready" || !topStories) return null;
 
     return html`
-      <div class=${containerStyles}>
-        <ol class=${listStyles}>
+      <div className=${containerStyles}>
+        <ol className=${listStyles}>
           ${topStories.map((id) => html`<${Story} key=${id} id=${id} />`)}
         </ol>
         ${loadMoreVisible &&
         html`
-          <div class=${buttonsStyles}>
-            <button onClick=${this.loadMore} class=${loadMoreStyles}>
+          <div className=${buttonsStyles}>
+            <button onClick=${this.loadMore} className=${loadMoreStyles}>
               Load more
             </button>
           </div>

--- a/examples/hackernews/public/components/Stories.js
+++ b/examples/hackernews/public/components/Stories.js
@@ -77,7 +77,7 @@ export class Stories {
         ${loadMoreVisible &&
         html`
           <div class=${buttonsStyles}>
-            <button @click=${this.loadMore} class=${loadMoreStyles}>
+            <button onClick=${this.loadMore} class=${loadMoreStyles}>
               Load more
             </button>
           </div>

--- a/examples/hackernews/public/components/Story.js
+++ b/examples/hackernews/public/components/Story.js
@@ -86,19 +86,19 @@ export class Story {
 
     if (status !== "ready") {
       return html`
-        <li class=${itemStyles} tabindex="0">
-          <div class=${titleStyles}><${Skeleton} /></div>
+        <li className=${itemStyles} tabindex="0">
+          <div className=${titleStyles}><${Skeleton} /></div>
           <div><${Skeleton} /></div>
         </li>
       `;
     }
 
     return html`
-      <li class=${itemStyles} ref=${this.setRef}>
+      <li className=${itemStyles} ref=${this.setRef}>
         <a
           href=${story.url}
           target="_blank"
-          class=${titleStyles}
+          className=${titleStyles}
           title=${story.title}
         >
           ${story.title}

--- a/examples/hackernews/public/components/TopBar.js
+++ b/examples/hackernews/public/components/TopBar.js
@@ -44,10 +44,10 @@ export class TopBar {
         <${Link}
           route="topStories"
           state=${{ scrollToTop: true }}
-          class=${homeStyles}
+          className=${homeStyles}
         >
-          <img src=${logo} class=${logoStyles} />
-          <span class=${brandStyles}>Hacker News</span>
+          <img src=${logo} className=${logoStyles} />
+          <span className=${brandStyles}>Hacker News</span>
         <//>
         <${ReloadButton} />
       </header>

--- a/examples/hackernews/public/models/news.js
+++ b/examples/hackernews/public/models/news.js
@@ -28,7 +28,7 @@ export const loadTopStories = () => ({
 export const reloadTopStories = () => ({
   name: "reloadTopStories",
   status: "reloadTopStories",
-  payload: async (_, api) => {
+  payload: async (api) => {
     const topStories = await api.loadTopStories();
 
     return {

--- a/examples/todomvc-preact/public/components/ClearCompletedButton.js
+++ b/examples/todomvc-preact/public/components/ClearCompletedButton.js
@@ -8,6 +8,8 @@ export const ClearCompletedButton = connect(({ dispatch }) => {
   };
 
   return html`
-    <button class="clear-completed" onClick=${onClick}>Clear completed</button>
+    <button className="clear-completed" onClick=${onClick}>
+      Clear completed
+    </button>
   `;
 });

--- a/examples/todomvc-preact/public/components/DestroyButton.js
+++ b/examples/todomvc-preact/public/components/DestroyButton.js
@@ -7,5 +7,5 @@ export const DestroyButton = connect(({ id, dispatch }) => {
     dispatch(removeTodo({ id }));
   };
 
-  return html`<button onClick=${onClick} class="destroy"></button> `;
+  return html`<button onClick=${onClick} className="destroy"></button> `;
 });

--- a/examples/todomvc-preact/public/components/Footer.js
+++ b/examples/todomvc-preact/public/components/Footer.js
@@ -7,11 +7,11 @@ import { ClearCompletedButton } from "./ClearCompletedButton.js";
 
 export const Footer = connect({ activeTodoCount }, ({ activeTodoCount }) => {
   return html`
-    <footer class="footer">
-      <span class="todo-count"
+    <footer className="footer">
+      <span className="todo-count"
         ><strong>${activeTodoCount}</strong> item left</span
       >
-      <ul class="filters">
+      <ul className="filters">
         <${VisibilityFilter} value="all">All<//>
         <${VisibilityFilter} value="active">Active<//>
         <${VisibilityFilter} value="completed">Completed<//>

--- a/examples/todomvc-preact/public/components/Header.js
+++ b/examples/todomvc-preact/public/components/Header.js
@@ -1,5 +1,5 @@
 import { html } from "htm/preact";
 
 export const Header = ({ children }) => html`
-  <header class="header">${children}</header>
+  <header className="header">${children}</header>
 `;

--- a/examples/todomvc-preact/public/components/RootView.js
+++ b/examples/todomvc-preact/public/components/RootView.js
@@ -12,7 +12,7 @@ export const RootView = () => html`
     <${Title}>todos<//>
     <${TodoInput} />
   <//>
-  <section class="main">
+  <section className="main">
     <${ToggleAll} />
     <${TodoList} />
   </section>

--- a/examples/todomvc-preact/public/components/TodoInput.js
+++ b/examples/todomvc-preact/public/components/TodoInput.js
@@ -13,7 +13,7 @@ export const TodoInput = connect(({ dispatch }) => {
 
   return html`
     <input
-      class="new-todo"
+      className="new-todo"
       placeholder="What needs to be done?"
       autofocus
       onKeyDown=${onKeyDown}

--- a/examples/todomvc-preact/public/components/TodoItem.js
+++ b/examples/todomvc-preact/public/components/TodoItem.js
@@ -43,14 +43,14 @@ export const TodoItem = connect(
 
     return html`
       <li
-        class=${classes(
+        className=${classes(
           todo.editing && "editing",
           todo.completed && "completed"
         )}
       >
-        <div class="view">
+        <div className="view">
           <input
-            class="toggle"
+            className="toggle"
             type="checkbox"
             onChange=${onChange}
             checked=${todo.completed}
@@ -60,7 +60,7 @@ export const TodoItem = connect(
         </div>
         <input
           ref=${(element) => element && element.focus()}
-          class="edit"
+          className="edit"
           value=${todo.text}
           onKeyUp=${onKeyUp}
           onBlur=${onBlur}

--- a/examples/todomvc-preact/public/components/TodoList.js
+++ b/examples/todomvc-preact/public/components/TodoList.js
@@ -7,7 +7,7 @@ export const TodoList = connect(
   { todos: filteredTodos },
   ({ todos }) =>
     html`
-      <ul class="todo-list">
+      <ul className="todo-list">
         ${todos.map(({ id }) => html`<${TodoItem} key=${id} id=${id} />`)}
       </ul>
     `

--- a/examples/todomvc-preact/public/components/ToggleAll.js
+++ b/examples/todomvc-preact/public/components/ToggleAll.js
@@ -12,7 +12,7 @@ export const ToggleAll = connect(
     return html`
       <input
         id="toggle-all"
-        class="toggle-all"
+        className="toggle-all"
         type="checkbox"
         checked=${activeTodoCount === 0}
         onChange=${onChange}

--- a/examples/todomvc-preact/public/components/VisibilityFilter.js
+++ b/examples/todomvc-preact/public/components/VisibilityFilter.js
@@ -16,7 +16,7 @@ export const VisibilityFilter = connect(
     return html`
       <li>
         <a
-          class=${visibilityFilter === value && "selected"}
+          className=${visibilityFilter === value && "selected"}
           href="#"
           onClick=${onClick}
           >${children}</a

--- a/examples/todomvc-screenreader/public/components/CreateTodoView.js
+++ b/examples/todomvc-screenreader/public/components/CreateTodoView.js
@@ -27,7 +27,7 @@ export class CreateTodoView {
       <main>
         <h2>Create todo</h2>
         <p>With this form, you can create new todos</p>
-        <form @submit=${this.onSubmit}>
+        <form onSubmit=${this.onSubmit}>
           <fieldset>
             <legend>Enter the text of the new todo</legend>
             <label for="todo-text">Todo text</label>

--- a/examples/todomvc-screenreader/public/components/EditTodoView.js
+++ b/examples/todomvc-screenreader/public/components/EditTodoView.js
@@ -39,7 +39,7 @@ export class EditTodoView {
       </header>
       <main>
         <h2>Update todo</h2>
-        <form @submit=${this.onSubmit}>
+        <form onSubmit=${this.onSubmit}>
           <fieldset>
             <legend>Change the text of the todo</legend>
             <label for="todo-text">Todo text</label>

--- a/examples/todomvc-screenreader/public/components/TodoListView.js
+++ b/examples/todomvc-screenreader/public/components/TodoListView.js
@@ -23,7 +23,9 @@ export class TodoListView {
         <p>Here is the list of all your todos.</p>
         <${TodoList} />
         <${VisibilityFilters} />
-        <button @click=${this.clearCompleteTodos}>Clear completed todos</button>
+        <button onClick=${this.clearCompleteTodos}>
+          Clear completed todos
+        </button>
       </main>
     `;
   }

--- a/examples/todomvc-screenreader/public/components/TodoView.js
+++ b/examples/todomvc-screenreader/public/components/TodoView.js
@@ -34,7 +34,7 @@ export class TodoView {
         <dt>Created at</dt>
         <dd>${todo.createdAt}</dd>
       </dl>
-      <button @click=${this.removeTodo}>Delete todo</button>
+      <button onClick=${this.removeTodo}>Delete todo</button>
     `;
   }
 }

--- a/examples/todomvc-screenreader/public/components/VisibilityFilters.js
+++ b/examples/todomvc-screenreader/public/components/VisibilityFilters.js
@@ -30,7 +30,7 @@ export class VisibilityFilters {
       <fieldset>
         <legend>Set the visibility filtering of the todos</legend>
         <label for="visibibility-filter">Visibility filter</label>
-        <select @change=${this.onChange}>
+        <select onChange=${this.onChange}>
           <${VisibilityfilterOption} value="all">All<//>
           <${VisibilityfilterOption} value="active">Active<//>
           <${VisibilityfilterOption} value="completed">Completed<//>

--- a/examples/todomvc/public/components/ClearCompletedButton.js
+++ b/examples/todomvc/public/components/ClearCompletedButton.js
@@ -10,7 +10,7 @@ export class ClearCompletedButton {
 
   render() {
     return html`
-      <button class="clear-completed" @click=${this.onClick}>
+      <button class="clear-completed" onClick=${this.onClick}>
         Clear completed
       </button>
     `;

--- a/examples/todomvc/public/components/ClearCompletedButton.js
+++ b/examples/todomvc/public/components/ClearCompletedButton.js
@@ -10,7 +10,7 @@ export class ClearCompletedButton {
 
   render() {
     return html`
-      <button class="clear-completed" onClick=${this.onClick}>
+      <button className="clear-completed" onClick=${this.onClick}>
         Clear completed
       </button>
     `;

--- a/examples/todomvc/public/components/DestroyButton.js
+++ b/examples/todomvc/public/components/DestroyButton.js
@@ -9,6 +9,6 @@ export class DestroyButton {
   }
 
   render() {
-    return html`<button @click=${this.onClick} class="destroy"></button> `;
+    return html`<button onClick=${this.onClick} class="destroy"></button> `;
   }
 }

--- a/examples/todomvc/public/components/DestroyButton.js
+++ b/examples/todomvc/public/components/DestroyButton.js
@@ -9,6 +9,6 @@ export class DestroyButton {
   }
 
   render() {
-    return html`<button onClick=${this.onClick} class="destroy"></button> `;
+    return html`<button onClick=${this.onClick} className="destroy"></button> `;
   }
 }

--- a/examples/todomvc/public/components/EditInput.js
+++ b/examples/todomvc/public/components/EditInput.js
@@ -33,7 +33,7 @@ export class EditInput {
     return html`
       <input
         ref=${this.createRef("input")}
-        class="edit"
+        className="edit"
         .value=${todo.text}
         onKeyDown=${this.onKeyDown}
         onBlur=${this.onBlur}

--- a/examples/todomvc/public/components/EditInput.js
+++ b/examples/todomvc/public/components/EditInput.js
@@ -35,8 +35,8 @@ export class EditInput {
         ref=${this.createRef("input")}
         class="edit"
         .value=${todo.text}
-        @keydown=${this.onKeyDown}
-        @blur=${this.onBlur}
+        onKeyDown=${this.onKeyDown}
+        onBlur=${this.onBlur}
       />
     `;
   }

--- a/examples/todomvc/public/components/Footer.js
+++ b/examples/todomvc/public/components/Footer.js
@@ -11,11 +11,11 @@ export class Footer {
 
   render({ activeTodoCount }) {
     return html`
-      <footer class="footer">
-        <span class="todo-count"
+      <footer className="footer">
+        <span className="todo-count"
           ><strong>${activeTodoCount}</strong> item left</span
         >
-        <ul class="filters">
+        <ul className="filters">
           <${VisibilityFilter} value="all">All<//>
           <${VisibilityFilter} value="active">Active<//>
           <${VisibilityFilter} value="completed">Completed<//>

--- a/examples/todomvc/public/components/Header.js
+++ b/examples/todomvc/public/components/Header.js
@@ -2,6 +2,6 @@ import { html } from "@depository/view";
 
 export class Header {
   render({ children }) {
-    return html`<header class="header">${children}</header>`;
+    return html`<header className="header">${children}</header>`;
   }
 }

--- a/examples/todomvc/public/components/RootView.js
+++ b/examples/todomvc/public/components/RootView.js
@@ -14,7 +14,7 @@ export class RootView {
         <${Title}>todos<//>
         <${TodoInput} />
       <//>
-      <section class="main">
+      <section className="main">
         <${ToggleAll} />
         <${TodoList} />
       </section>

--- a/examples/todomvc/public/components/TodoInput.js
+++ b/examples/todomvc/public/components/TodoInput.js
@@ -14,7 +14,7 @@ export class TodoInput {
   render() {
     return html`
       <input
-        class="new-todo"
+        className="new-todo"
         placeholder="What needs to be done?"
         autofocus
         onKeyDown=${this.onKeyDown}

--- a/examples/todomvc/public/components/TodoInput.js
+++ b/examples/todomvc/public/components/TodoInput.js
@@ -17,7 +17,7 @@ export class TodoInput {
         class="new-todo"
         placeholder="What needs to be done?"
         autofocus
-        @keydown=${this.onKeyDown}
+        onKeyDown=${this.onKeyDown}
       />
     `;
   }

--- a/examples/todomvc/public/components/TodoItem.js
+++ b/examples/todomvc/public/components/TodoItem.js
@@ -35,14 +35,14 @@ export class TodoItem {
   render({ todo }) {
     return html`
       <li
-        class=${classes(
+        className=${classes(
           todo.editing && "editing",
           todo.completed && "completed"
         )}
       >
-        <div class="view">
+        <div className="view">
           <input
-            class="toggle"
+            className="toggle"
             type="checkbox"
             onChange=${this.onChange}
             .checked=${todo.completed}

--- a/examples/todomvc/public/components/TodoItem.js
+++ b/examples/todomvc/public/components/TodoItem.js
@@ -44,10 +44,10 @@ export class TodoItem {
           <input
             class="toggle"
             type="checkbox"
-            @change=${this.onChange}
+            onChange=${this.onChange}
             .checked=${todo.completed}
           />
-          <label @dblclick=${this.onDblClick}>${todo.text}</label>
+          <label onDblClick=${this.onDblClick}>${todo.text}</label>
           <${DestroyButton} id=${todo.id} />
         </div>
         ${this.renderInput({ todo })}

--- a/examples/todomvc/public/components/TodoList.js
+++ b/examples/todomvc/public/components/TodoList.js
@@ -9,7 +9,7 @@ export class TodoList {
 
   render({ todos }) {
     return html`
-      <ul class="todo-list">
+      <ul className="todo-list">
         ${todos.map(({ id }) => html`<${TodoItem} key=${id} id=${id} />`)}
       </ul>
     `;

--- a/examples/todomvc/public/components/ToggleAll.js
+++ b/examples/todomvc/public/components/ToggleAll.js
@@ -16,7 +16,7 @@ export class ToggleAll {
     return html`
       <input
         id="toggle-all"
-        class="toggle-all"
+        className="toggle-all"
         type="checkbox"
         .checked=${activeTodoCount === 0}
         onChange=${this.onChange}

--- a/examples/todomvc/public/components/ToggleAll.js
+++ b/examples/todomvc/public/components/ToggleAll.js
@@ -19,7 +19,7 @@ export class ToggleAll {
         class="toggle-all"
         type="checkbox"
         .checked=${activeTodoCount === 0}
-        @change=${this.onChange}
+        onChange=${this.onChange}
       />
       <label for="toggle-all">Mark all as complete</label>
     `;

--- a/examples/todomvc/public/components/VisibilityFilter.js
+++ b/examples/todomvc/public/components/VisibilityFilter.js
@@ -21,7 +21,7 @@ export class VisibilityFilter {
   render({ value, isSelected, children }) {
     return html`
       <li>
-        <a class=${isSelected && "selected"} href="#" @click=${this.onClick}>
+        <a class=${isSelected && "selected"} href="#" onClick=${this.onClick}>
           ${children}
         </a>
       </li>

--- a/examples/todomvc/public/components/VisibilityFilter.js
+++ b/examples/todomvc/public/components/VisibilityFilter.js
@@ -21,7 +21,11 @@ export class VisibilityFilter {
   render({ value, isSelected, children }) {
     return html`
       <li>
-        <a class=${isSelected && "selected"} href="#" onClick=${this.onClick}>
+        <a
+          className=${isSelected && "selected"}
+          href="#"
+          onClick=${this.onClick}
+        >
           ${children}
         </a>
       </li>

--- a/packages/components/src/Anchor.js
+++ b/packages/components/src/Anchor.js
@@ -21,9 +21,9 @@ const styles = css`
 `;
 
 export class Anchor {
-  render({ children, class: className, ...other }) {
+  render({ children, className, ...other }) {
     return html`
-      <a class=${classes(styles, className)} ...${other}>${children}</a>
+      <a className=${classes(styles, className)} ...${other}>${children}</a>
     `;
   }
 }

--- a/packages/components/src/BorderLayout.js
+++ b/packages/components/src/BorderLayout.js
@@ -15,10 +15,10 @@ const containerStyles = ({ gap, stretched }) => css`
 `;
 
 export class BorderLayout {
-  render({ class: className, stretched, gap = "0", children, ...other }) {
+  render({ className, stretched, gap = "0", children, ...other }) {
     return html`
       <div
-        class=${classes(containerStyles({ stretched }), className)}
+        className=${classes(containerStyles({ stretched }), className)}
         ...${other}
       >
         ${children}

--- a/packages/components/src/Button.js
+++ b/packages/components/src/Button.js
@@ -119,14 +119,14 @@ export class Button {
     stretched,
     disabled,
     loading,
-    class: className,
+    className,
     children,
     onClick,
     ...other
   }) {
     return html`
       <button
-        class=${classes(
+        className=${classes(
           styles,
           basic && basicStyles,
           primary && primaryStyles,
@@ -137,8 +137,8 @@ export class Button {
         onClick=${loading ? null : onClick}
         ...${other}
       >
-        ${loading && html`<div class=${loaderStyles}><${Pulse} /></div>`}
-        <span class=${classes(childrenStyles, loading && loadingStyles)}>
+        ${loading && html`<div className=${loaderStyles}><${Pulse} /></div>`}
+        <span className=${classes(childrenStyles, loading && loadingStyles)}>
           ${children}
         </span>
       </button>

--- a/packages/components/src/Button.js
+++ b/packages/components/src/Button.js
@@ -121,7 +121,7 @@ export class Button {
     loading,
     class: className,
     children,
-    "@click": onClick,
+    onClick,
     ...other
   }) {
     return html`
@@ -134,7 +134,7 @@ export class Button {
           className
         )}
         disabled=${disabled}
-        @click=${loading ? null : onClick}
+        onClick=${loading ? null : onClick}
         ...${other}
       >
         ${loading && html`<div class=${loaderStyles}><${Pulse} /></div>`}

--- a/packages/components/src/Center.js
+++ b/packages/components/src/Center.js
@@ -15,9 +15,9 @@ export class Center {
     return { stretched: false };
   }
 
-  render({ class: className, children, stretched, ...other }) {
+  render({ className, children, stretched, ...other }) {
     return html`
-      <div class=${classes(styles({ stretched }), className)} ...${other}>
+      <div className=${classes(styles({ stretched }), className)} ...${other}>
         ${children}
       </div>
     `;

--- a/packages/components/src/Checkbox.js
+++ b/packages/components/src/Checkbox.js
@@ -87,14 +87,14 @@ export class Checkbox {
       <input
         type="checkbox"
         id=${id}
-        class=${classes(className, styles)}
+        className=${classes(className, styles)}
         checked=${checked}
         .indeterminate=${indeterminate}
         ...${other}
       />
       <label for=${id}>
-        <${DashFill12Icon} class=${`${styles}-dash-icon`} />
-        <${CheckSmFill12Icon} class=${`${styles}-checked-icon`} />
+        <${DashFill12Icon} className=${`${styles}-dash-icon`} />
+        <${CheckSmFill12Icon} className=${`${styles}-checked-icon`} />
       </label>
     `;
   }

--- a/packages/components/src/ColumnLayout.js
+++ b/packages/components/src/ColumnLayout.js
@@ -32,13 +32,13 @@ export class ColumnLayout {
     stretched,
     alignItems = "center",
     justifyItems = "center",
-    class: className,
+    className,
     children,
     ...other
   }) {
     return html`
       <div
-        class=${classes(
+        className=${classes(
           styles({ gap, stretched, columns, alignItems, justifyItems }),
           stretched && stretchedStyles,
           className

--- a/packages/components/src/IconButton.js
+++ b/packages/components/src/IconButton.js
@@ -16,10 +16,10 @@ const pillStyles = css`
 `;
 
 export class IconButton {
-  render({ class: className, pill, children, ...other }) {
+  render({ className, pill, children, ...other }) {
     return html`
       <${Button}
-        class=${classes(styles, pill && pillStyles, className)}
+        className=${classes(styles, pill && pillStyles, className)}
         ...${other}
       >
         ${children}

--- a/packages/components/src/MediaInput.js
+++ b/packages/components/src/MediaInput.js
@@ -66,14 +66,14 @@ export class MediaInput {
     }
   }
 
-  render({ ref, class: className, children, ...other }) {
+  render({ ref, className, children, ...other }) {
     const input = children.find(({ type }) => type === "input");
     const disabled = input.props[".disabled"] || input.props.disabled;
 
     return html`
       <span
         ref=${combineRefs(this.createRef("ref"), ref)}
-        class=${classes(className, mediaInputStyles, textInputStyles)}
+        className=${classes(className, mediaInputStyles, textInputStyles)}
         disabled=${disabled}
         onMouseDown=${this.focusInput}
         ...${other}

--- a/packages/components/src/MediaInput.js
+++ b/packages/components/src/MediaInput.js
@@ -47,7 +47,7 @@ export class MediaInput {
     };
 
     this.onBlur = (e) => {
-      const blurHandler = this.props["@blur"];
+      const blurHandler = this.props.onBlur;
       blurHandler && blurHandler(e);
     };
   }
@@ -75,7 +75,7 @@ export class MediaInput {
         ref=${combineRefs(this.createRef("ref"), ref)}
         class=${classes(className, mediaInputStyles, textInputStyles)}
         disabled=${disabled}
-        @mousedown=${this.focusInput}
+        onMouseDown=${this.focusInput}
         ...${other}
       >
         ${children}

--- a/packages/components/src/Menu.js
+++ b/packages/components/src/Menu.js
@@ -29,7 +29,7 @@ export class Menu {
       if (this.props.visible) {
         this.dispatch(hideMenu({ id: this.props.id }));
 
-        const hideHandler = this.props["@hide"];
+        const hideHandler = this.props.onHide;
         hideHandler && hideHandler();
       }
     };
@@ -47,7 +47,7 @@ export class Menu {
     };
 
     this.onSelect = (e) => {
-      const onSelect = this.props["@selectItem"];
+      const onSelect = this.props.onSelectItem;
       if (onSelect) {
         onSelect(e);
         if (!e.defaultPrevented) this.hideMenu();
@@ -135,12 +135,12 @@ export class Menu {
         "aria-expanded": visible ? "true" : "false",
         "aria-controls": `${id}-menu`,
         "aria-activedescendant": focused && `${id}-${focused}`,
-        "@click": this.onTriggerClick,
-        "@keydown": this.onKeydown,
-        "@blur": this.onBlur,
+        onClick: this.onTriggerClick,
+        onKeyDown: this.onKeydown,
+        onBlur: this.onBlur,
       }),
       html`
-        <div ref=${this.createRef("popupRef")} @selectItem=${this.onSelect}>
+        <div ref=${this.createRef("popupRef")} onSelectItem=${this.onSelect}>
           ${visible &&
           clone(content, {
             id: `${id}-menu`,

--- a/packages/components/src/Menu/MenuButton.js
+++ b/packages/components/src/Menu/MenuButton.js
@@ -7,7 +7,7 @@ export class MenuButton {
   render({ children, ...other }) {
     return html`
       <${Button} ...${other}>
-        ${children}<${ChevronDownStroke12Icon} class=${ms1} />
+        ${children}<${ChevronDownStroke12Icon} className=${ms1} />
       <//>
     `;
   }

--- a/packages/components/src/Menu/MenuItem.js
+++ b/packages/components/src/Menu/MenuItem.js
@@ -73,8 +73,8 @@ export class MenuItem {
         tabindex="-1"
         id="${id}-${key}"
         role="menuitem"
-        @mousedown=${this.onMouseDown}
-        @mouseenter=${this.onMouseEnter}
+        onMouseDown=${this.onMouseDown}
+        onMouseEnter=${this.onMouseEnter}
         class=${classes(styles, focused && focusedStyles)}
         ...${other}
       >

--- a/packages/components/src/Menu/MenuItem.js
+++ b/packages/components/src/Menu/MenuItem.js
@@ -75,7 +75,7 @@ export class MenuItem {
         role="menuitem"
         onMouseDown=${this.onMouseDown}
         onMouseEnter=${this.onMouseEnter}
-        class=${classes(styles, focused && focusedStyles)}
+        className=${classes(styles, focused && focusedStyles)}
         ...${other}
       >
         ${children}

--- a/packages/components/src/Menu/MenuItemNext.js
+++ b/packages/components/src/Menu/MenuItemNext.js
@@ -45,11 +45,11 @@ export class MenuItemNext {
     return html`
       <${MenuItem} ref=${this.createRef("ref")} ...${other}>
         <${ChevronLeftStroke16Icon}
-          class=${classes(iconStyles, leftIconStyles)}
+          className=${classes(iconStyles, leftIconStyles)}
         />
         ${children}
         <${ChevronRightStroke16Icon}
-          class=${classes(iconStyles, rightIconStyles)}
+          className=${classes(iconStyles, rightIconStyles)}
         />
       <//>
     `;

--- a/packages/components/src/Menu/MenuItemPrevious.js
+++ b/packages/components/src/Menu/MenuItemPrevious.js
@@ -45,11 +45,11 @@ export class MenuItemPrevious {
     return html`
       <${MenuItem} ref=${this.createRef("ref")} ...${other}>
         <${ChevronLeftStroke16Icon}
-          class=${classes(iconStyles, leftIconStyles)}
+          className=${classes(iconStyles, leftIconStyles)}
         />
         ${children}
         <${ChevronRightStroke16Icon}
-          class=${classes(iconStyles, rightIconStyles)}
+          className=${classes(iconStyles, rightIconStyles)}
         />
       <//>
     `;

--- a/packages/components/src/Menu/MenuPopup.js
+++ b/packages/components/src/Menu/MenuPopup.js
@@ -74,7 +74,7 @@ const styles = css`
 export class MenuPopup {
   render({ children, ...other }) {
     return html`
-      <div role="menu" class=${styles} ...${other}>${children}</div>
+      <div role="menu" className=${styles} ...${other}>${children}</div>
     `;
   }
 }

--- a/packages/components/src/Menu/model.js
+++ b/packages/components/src/Menu/model.js
@@ -85,7 +85,7 @@ export const focusNextItem = ({ id, selectable }) => {
 
 export class SelectEvent extends CustomEvent {
   constructor(detail) {
-    super("selectItem", {
+    super("SelectItem", {
       detail,
       bubbles: true,
       cancelable: true,

--- a/packages/components/src/NestedMenu.js
+++ b/packages/components/src/NestedMenu.js
@@ -4,7 +4,7 @@ import { Menu } from "./Menu.js";
 
 class MenuChangedEvent extends CustomEvent {
   constructor({ menu, selectedItem }) {
-    super("menuChanged", {
+    super("MenuChanged", {
       detail: { menu, selectedItem },
       bubbles: true,
       cancelable: true,
@@ -21,7 +21,7 @@ export class NestedMenu {
         (item) => item.props.key === key
       );
 
-      const onMenuChanged = this.props["@menuChanged"];
+      const onMenuChanged = this.props.onMenuChanged;
 
       if (item.type.isNextAction) {
         if (onMenuChanged) {
@@ -42,7 +42,7 @@ export class NestedMenu {
 
         e.preventDefault();
       } else {
-        const onSelect = this.props["@selectItem"];
+        const onSelect = this.props.onSelectItem;
         onSelect && onSelect(e);
       }
     };
@@ -50,7 +50,7 @@ export class NestedMenu {
 
   render({ children, ...other }) {
     return html`
-      <${Menu} ...${other} @selectItem=${this.onSelect}>${children}<//>
+      <${Menu} ...${other} onSelectItem=${this.onSelect}>${children}<//>
     `;
   }
 }

--- a/packages/components/src/Pulse.js
+++ b/packages/components/src/Pulse.js
@@ -70,9 +70,9 @@ const styles = css`
 `;
 
 export class Pulse {
-  render({ class: className }) {
+  render({ className }) {
     return html`
-      <div class=${classes(styles, className)} role="progressbar">
+      <div className=${classes(styles, className)} role="progressbar">
         <div></div>
         <div></div>
         <div></div>

--- a/packages/components/src/ScrollArea.js
+++ b/packages/components/src/ScrollArea.js
@@ -15,10 +15,10 @@ const overflowStyles = (overflow) => css`
 `;
 
 export class ScrollArea {
-  render({ overflow = "hidden auto", class: className, children, ...other }) {
+  render({ overflow = "hidden auto", className, children, ...other }) {
     return html`
       <div
-        class=${classes(styles, overflowStyles(overflow), className)}
+        className=${classes(styles, overflowStyles(overflow), className)}
         ...${other}
       >
         ${children}

--- a/packages/components/src/Select/SelectInput.js
+++ b/packages/components/src/Select/SelectInput.js
@@ -28,7 +28,7 @@ export class SelectInput {
       <${MediaInput} ...${containerProps}>
         <span data-label>${children}</span>
         <input type="text" ...${inputProps} />
-        <${ChevronDownStroke12Icon} class=${ms1} />
+        <${ChevronDownStroke12Icon} className=${ms1} />
       <//>
     `;
   }

--- a/packages/components/src/Select/SelectInput.js
+++ b/packages/components/src/Select/SelectInput.js
@@ -6,7 +6,7 @@ import { MediaInput } from "../MediaInput.js";
 const inputProps = [
   "id",
   "role",
-  "@blur",
+  "onBlur",
   "value",
   ".value",
   "disabled",

--- a/packages/components/src/Select/SelectOption.js
+++ b/packages/components/src/Select/SelectOption.js
@@ -22,7 +22,7 @@ const iconStyles = css`
 
 export class SelectOption {
   renderIcon() {
-    return html`<div class=${iconStyles}><${CheckLgStroke16Icon} /></div>`;
+    return html`<div className=${iconStyles}><${CheckLgStroke16Icon} /></div>`;
   }
 
   render({ children, selected, ...other }) {

--- a/packages/components/src/Skeleton.js
+++ b/packages/components/src/Skeleton.js
@@ -48,7 +48,7 @@ const styles = css`
 `;
 
 export class Skeleton {
-  render({ class: className }) {
-    return html`<div class=${classes(styles, className)}>${"\u00A0"}</div>`;
+  render({ className }) {
+    return html`<div className=${classes(styles, className)}>${"\u00A0"}</div>`;
   }
 }

--- a/packages/components/src/Spinner.js
+++ b/packages/components/src/Spinner.js
@@ -33,9 +33,9 @@ const styles = css`
 `;
 
 export class Spinner {
-  render({ class: className }) {
+  render({ className }) {
     return html`
-      <div class=${classes(styles, className)} role="progressbar">
+      <div className=${classes(styles, className)} role="progressbar">
         Loading...
       </div>
     `;

--- a/packages/components/src/Switch.js
+++ b/packages/components/src/Switch.js
@@ -86,7 +86,7 @@ export class Switch {
       <input
         type="checkbox"
         id=${id}
-        class=${classes(className, styles)}
+        className=${classes(className, styles)}
         checked=${checked}
         .indeterminate=${indeterminate}
         ...${other}

--- a/packages/components/src/TextInput.js
+++ b/packages/components/src/TextInput.js
@@ -50,11 +50,11 @@ export const textInputStyles = css`
 `;
 
 export class TextInput {
-  render({ class: className, ...other }) {
+  render({ className, ...other }) {
     return html`
       <input
         type="text"
-        class=${classes(className, textInputStyles)}
+        className=${classes(className, textInputStyles)}
         ...${other}
       />
     `;

--- a/packages/devtools/components/Action.js
+++ b/packages/devtools/components/Action.js
@@ -120,13 +120,13 @@ export class Action {
   render({ name, isSelected }) {
     return html`<div
       ref=${this.setRef}
-      class=${classes(actionStyles, isSelected && selectedStyles)}
+      className=${classes(actionStyles, isSelected && selectedStyles)}
       onClick=${this.onShow}
       onKeyDown=${this.onKeyDown}
       tabindex="0"
     >
-      <div class=${labelStyles}>${name}</div>
-      <div class="restore" onClick=${this.onRestore}>Restore</div>
+      <div className=${labelStyles}>${name}</div>
+      <div className="restore" onClick=${this.onRestore}>Restore</div>
     </div>`;
   }
 }

--- a/packages/devtools/components/Action.js
+++ b/packages/devtools/components/Action.js
@@ -121,12 +121,12 @@ export class Action {
     return html`<div
       ref=${this.setRef}
       class=${classes(actionStyles, isSelected && selectedStyles)}
-      @click=${this.onShow}
-      @keydown=${this.onKeyDown}
+      onClick=${this.onShow}
+      onKeyDown=${this.onKeyDown}
       tabindex="0"
     >
       <div class=${labelStyles}>${name}</div>
-      <div class="restore" @click=${this.onRestore}>Restore</div>
+      <div class="restore" onClick=${this.onRestore}>Restore</div>
     </div>`;
   }
 }

--- a/packages/devtools/components/Actions.js
+++ b/packages/devtools/components/Actions.js
@@ -35,7 +35,7 @@ export class Actions {
     return html`
       <${ErrorBoundary} name="actions">
         <${Sidebar}>
-          <nav class=${navStyles} @keydown=${this.onKeyDown}>
+          <nav class=${navStyles} onKeyDown=${this.onKeyDown}>
             ${updates.map((_, index) => html`<${Action} index=${index} />`)}
           </nav>
         <//>

--- a/packages/devtools/components/Actions.js
+++ b/packages/devtools/components/Actions.js
@@ -35,7 +35,7 @@ export class Actions {
     return html`
       <${ErrorBoundary} name="actions">
         <${Sidebar}>
-          <nav class=${navStyles} onKeyDown=${this.onKeyDown}>
+          <nav className=${navStyles} onKeyDown=${this.onKeyDown}>
             ${updates.map((_, index) => html`<${Action} index=${index} />`)}
           </nav>
         <//>

--- a/packages/devtools/components/Details.js
+++ b/packages/devtools/components/Details.js
@@ -28,7 +28,7 @@ class ActionPanel {
     if (!update) return null;
 
     return html`
-      <section class=${detailsStyles}>
+      <section className=${detailsStyles}>
         <${JSONView} id="actionJson" value=${update.action} />
       </section>
     `;
@@ -44,7 +44,7 @@ class StatePanel {
     if (!update) return null;
 
     return html`
-      <section class=${detailsStyles}>
+      <section className=${detailsStyles}>
         <${JSONView} id="stateJson" value=${update.state} />
       </section>
     `;

--- a/packages/devtools/components/JSONView.js
+++ b/packages/devtools/components/JSONView.js
@@ -10,7 +10,7 @@ const numberStyles = css`
 
 class JSONNumber {
   render({ value }) {
-    return html`<span class=${numberStyles}>${value}</span>`;
+    return html`<span className=${numberStyles}>${value}</span>`;
   }
 }
 
@@ -22,7 +22,7 @@ const stringStyles = css`
 
 class JSONString {
   render({ value }) {
-    return html`<span class=${stringStyles}>"${String(value)}"</span>`;
+    return html`<span className=${stringStyles}>"${String(value)}"</span>`;
   }
 }
 
@@ -34,7 +34,7 @@ const booleanStyles = css`
 
 class JSONBoolean {
   render({ value }) {
-    return html`<span class=${booleanStyles}>${String(value)}</span>`;
+    return html`<span className=${booleanStyles}>${String(value)}</span>`;
   }
 }
 
@@ -46,7 +46,7 @@ const undefinedStyles = css`
 
 class JSONUndefined {
   render({ value }) {
-    return html`<span class=${undefinedStyles}>${String(value)}</span>`;
+    return html`<span className=${undefinedStyles}>${String(value)}</span>`;
   }
 }
 
@@ -58,7 +58,7 @@ const nullStyles = css`
 
 class JSONNull {
   render({ value }) {
-    return html`<span class=${nullStyles}>${String(value)}</span>`;
+    return html`<span className=${nullStyles}>${String(value)}</span>`;
   }
 }
 
@@ -72,7 +72,7 @@ const keyStyles = css`
 class JSONEntry {
   render({ id, key, value }) {
     return html`<div key=${key}>
-      <span class=${keyStyles}>${key}:</span>
+      <span className=${keyStyles}>${key}:</span>
       <${JSONValue} id=${id} value=${value} />
     </div>`;
   }
@@ -107,7 +107,7 @@ class ItemCount {
     const label = `${count} ${count === 1 ? "item" : "items"}`;
 
     return html`
-      <span onClick=${this.toggle} class=${itemCountStyles}>${label}</span>
+      <span onClick=${this.toggle} className=${itemCountStyles}>${label}</span>
     `;
   }
 }
@@ -139,8 +139,8 @@ class JSONCollectionBody {
   render({ id, entries }) {
     return html`
       <${ItemCount} id=${id} count=${entries.length} />
-      <div onClick=${this.toggle} class=${jsonCollectionBodyStyles}>
-        <div onClick=${stopPropagation} class=${ignoreClickStyles}>
+      <div onClick=${this.toggle} className=${jsonCollectionBodyStyles}>
+        <div onClick=${stopPropagation} className=${ignoreClickStyles}>
           ${entries.map(
             ([key, value]) =>
               html`<${JSONEntry}
@@ -241,7 +241,7 @@ const theme = css`
 export class JSONView {
   render({ id, value }) {
     return html`
-      <div class=${classes(theme)}>
+      <div className=${classes(theme)}>
         <${JSONValue} id=${id + ".view"} value=${value} />
       </div>
     `;

--- a/packages/devtools/components/JSONView.js
+++ b/packages/devtools/components/JSONView.js
@@ -107,7 +107,7 @@ class ItemCount {
     const label = `${count} ${count === 1 ? "item" : "items"}`;
 
     return html`
-      <span @click=${this.toggle} class=${itemCountStyles}>${label}</span>
+      <span onClick=${this.toggle} class=${itemCountStyles}>${label}</span>
     `;
   }
 }
@@ -139,8 +139,8 @@ class JSONCollectionBody {
   render({ id, entries }) {
     return html`
       <${ItemCount} id=${id} count=${entries.length} />
-      <div @click=${this.toggle} class=${jsonCollectionBodyStyles}>
-        <div @click=${stopPropagation} class=${ignoreClickStyles}>
+      <div onClick=${this.toggle} class=${jsonCollectionBodyStyles}>
+        <div onClick=${stopPropagation} class=${ignoreClickStyles}>
           ${entries.map(
             ([key, value]) =>
               html`<${JSONEntry}

--- a/packages/devtools/components/NotConnected.js
+++ b/packages/devtools/components/NotConnected.js
@@ -16,7 +16,7 @@ const centeredStyles = css`
 export class NotConnected {
   render() {
     return html`
-      <div class=${centeredStyles}>
+      <div className=${centeredStyles}>
         <h1>Not connected</h1>
       </div>
     `;

--- a/packages/devtools/components/Root.js
+++ b/packages/devtools/components/Root.js
@@ -34,7 +34,7 @@ export class Root {
 
     return html`
       <${ErrorBoundary} name="root">
-        <main class=${mainStyles}><${Actions} /><${Details} /></main>
+        <main className=${mainStyles}><${Actions} /><${Details} /></main>
       <//>
     `;
   }

--- a/packages/devtools/components/Sidebar.js
+++ b/packages/devtools/components/Sidebar.js
@@ -11,6 +11,6 @@ const sidebarStyles = css`
 
 export class Sidebar {
   render({ children }) {
-    return html`<div class=${sidebarStyles}>${children}</div>`;
+    return html`<div className=${sidebarStyles}>${children}</div>`;
   }
 }

--- a/packages/devtools/components/Tabs.js
+++ b/packages/devtools/components/Tabs.js
@@ -47,7 +47,7 @@ export class Tab {
 
   render({ children, isActive, ...other }) {
     return html`<button
-      class=${classes(tabStyles, isActive && activeStyles)}
+      className=${classes(tabStyles, isActive && activeStyles)}
       onClick=${this.activate}
       ...${other}
     >
@@ -77,7 +77,7 @@ const tabListStyles = css`
 
 export class TabList {
   render({ children }) {
-    return html`<div class=${tabListStyles}>${children}</div>`;
+    return html`<div className=${tabListStyles}>${children}</div>`;
   }
 }
 
@@ -99,6 +99,6 @@ export class Tabs {
   }
 
   render({ children }) {
-    return html`<div class=${tabsStyles}>${children}</div>`;
+    return html`<div className=${tabsStyles}>${children}</div>`;
   }
 }

--- a/packages/devtools/components/Tabs.js
+++ b/packages/devtools/components/Tabs.js
@@ -48,7 +48,7 @@ export class Tab {
   render({ children, isActive, ...other }) {
     return html`<button
       class=${classes(tabStyles, isActive && activeStyles)}
-      @click=${this.activate}
+      onClick=${this.activate}
       ...${other}
     >
       ${children}

--- a/packages/nano-router-plugin/src/Link.js
+++ b/packages/nano-router-plugin/src/Link.js
@@ -48,14 +48,14 @@ export class Link {
           href=${this.href}
           rel="noopener"
           target=${target}
-          @click=${this.onClick}
+          onClick=${this.onClick}
           ...${other}
         >
           ${children}
         </a>
       `;
     } else {
-      return html`<a href=${this.href} @click=${this.onClick} ...${other}
+      return html`<a href=${this.href} onClick=${this.onClick} ...${other}
         >${children}</a
       >`;
     }

--- a/packages/styleguide/src/components/DefaultLayout.js
+++ b/packages/styleguide/src/components/DefaultLayout.js
@@ -89,10 +89,10 @@ export class DefaultLayout {
 
   render({ children }) {
     return html`
-      <${BorderLayout} stretched class=${rootStyles}>
+      <${BorderLayout} stretched className=${rootStyles}>
         <${TopBar} />
         <${Sidebar}>${this.context.navigation}<//>
-        <main class=${mainStyles} ref=${this.setContentRef}>
+        <main className=${mainStyles} ref=${this.setContentRef}>
           <${ErrorBoundary} name="default-layout">${children}<//>
         </main>
       <//>

--- a/packages/styleguide/src/components/DirectionSwitch.js
+++ b/packages/styleguide/src/components/DirectionSwitch.js
@@ -18,7 +18,7 @@ export class DirectionSwitch {
       <${ColumnLayout} columns="2" gap="10">
         <${Switch}
           id="direction-switch"
-          @change=${this.toggle}
+          onChange=${this.toggle}
           .checked=${dir === "rtl"}
         />
         <label for="direction-switch">RTL</label>

--- a/packages/styleguide/src/components/Example.js
+++ b/packages/styleguide/src/components/Example.js
@@ -63,7 +63,7 @@ export class Example {
         <${ExamplePreview}>${children}<//>
         <div class=${buttonsStyles}>
           <${JSFiddleButton} src=${src} />
-          <${IconButton} basic @click=${this.onToggleSource}>
+          <${IconButton} basic onClick=${this.onToggleSource}>
             <${MarkupStroke16Icon} />
           <//>
         </div>

--- a/packages/styleguide/src/components/Example.js
+++ b/packages/styleguide/src/components/Example.js
@@ -59,9 +59,9 @@ export class Example {
 
   render({ children, sourceVisible, src, columns = 1, stretched }) {
     return html`
-      <div class=${styles}>
+      <div className=${styles}>
         <${ExamplePreview}>${children}<//>
-        <div class=${buttonsStyles}>
+        <div className=${buttonsStyles}>
           <${JSFiddleButton} src=${src} />
           <${IconButton} basic onClick=${this.onToggleSource}>
             <${MarkupStroke16Icon} />

--- a/packages/styleguide/src/components/ExamplePreview.js
+++ b/packages/styleguide/src/components/ExamplePreview.js
@@ -13,6 +13,6 @@ export class ExamplePreview {
   }
 
   render({ dir, children }) {
-    return html`<div dir=${dir} class=${styles}>${children}</div>`;
+    return html`<div dir=${dir} className=${styles}>${children}</div>`;
   }
 }

--- a/packages/styleguide/src/components/JSFiddleButton.js
+++ b/packages/styleguide/src/components/JSFiddleButton.js
@@ -78,7 +78,7 @@ export class JSFiddleButton {
         method="post"
         target="_blank"
         action="https://jsfiddle.net/api/post/library/pure/"
-        class=${formStyles}
+        className=${formStyles}
       >
         <input type="hidden" name="title" value="@depository/components" />
         <input

--- a/packages/styleguide/src/components/JSFiddleButton.js
+++ b/packages/styleguide/src/components/JSFiddleButton.js
@@ -70,7 +70,7 @@ export class JSFiddleButton {
 
   render() {
     return html`
-      <${IconButton} basic @click=${this.onClick}>
+      <${IconButton} basic onClick=${this.onClick}>
         <${JSFiddleLogo} />
       <//>
       <form

--- a/packages/styleguide/src/components/Page.js
+++ b/packages/styleguide/src/components/Page.js
@@ -20,8 +20,8 @@ export class Page {
     }
   }
 
-  render({ class: className, children }) {
-    return html`<div class=${classes(contentStyles, className)}>
+  render({ className, children }) {
+    return html`<div className=${classes(contentStyles, className)}>
       ${children}
     </div>`;
   }
@@ -65,14 +65,14 @@ export class Heading {
     return this.props.children.join("").replace(/\s+/g, "-").toLowerCase();
   }
 
-  render({ children, class: className, level, ...other }) {
+  render({ children, className, level, ...other }) {
     const type = `h${level}`;
     const name = this.name;
 
     return html`
       <a name=${name} />
-      <${type} class=${classes(headingStyles, className)} ...${other}>
-        <div class=${headingLinkStyles}>
+      <${type} className=${classes(headingStyles, className)} ...${other}>
+        <div className=${headingLinkStyles}>
           <${IconButton} pill basic onClick=${this.onClick}>
             <${LinkStroke16Icon} />
           <//>
@@ -95,7 +95,7 @@ const titleStyles = css`
 
 export class Title {
   render({ children }) {
-    return html`<${Heading} level="1" class=${titleStyles}>${children}<//>`;
+    return html`<${Heading} level="1" className=${titleStyles}>${children}<//>`;
   }
 }
 
@@ -108,7 +108,7 @@ const subTitleStyles = css`
 
 export class SubTitle {
   render({ children }) {
-    return html`<p class=${subTitleStyles}>${children}</p>`;
+    return html`<p className=${subTitleStyles}>${children}</p>`;
   }
 }
 
@@ -121,7 +121,7 @@ const lineStyles = css`
 
 export class Line {
   render() {
-    return html`<hr class=${lineStyles} />`;
+    return html`<hr className=${lineStyles} />`;
   }
 }
 
@@ -134,7 +134,7 @@ const skeletonStyles = css`
 export class PageSkeleton {
   render() {
     return html`
-      <${Page} class=${skeletonStyles}>
+      <${Page} className=${skeletonStyles}>
         <${Title}><${Skeleton} /><//>
         <${SubTitle}><${Skeleton} /><//>
         <${Line}/>

--- a/packages/styleguide/src/components/Page.js
+++ b/packages/styleguide/src/components/Page.js
@@ -73,7 +73,7 @@ export class Heading {
       <a name=${name} />
       <${type} class=${classes(headingStyles, className)} ...${other}>
         <div class=${headingLinkStyles}>
-          <${IconButton} pill basic @click=${this.onClick}>
+          <${IconButton} pill basic onClick=${this.onClick}>
             <${LinkStroke16Icon} />
           <//>
         </div>

--- a/packages/styleguide/src/components/PageReference.js
+++ b/packages/styleguide/src/components/PageReference.js
@@ -45,7 +45,7 @@ export class PageReference {
         route="page"
         params=${{ id }}
         hash=""
-        class=${classes(styles, isActive && activeStyles)}
+        className=${classes(styles, isActive && activeStyles)}
         ...${other}
       >
         ${children}

--- a/packages/styleguide/src/components/Sidebar.js
+++ b/packages/styleguide/src/components/Sidebar.js
@@ -28,6 +28,6 @@ const sidebarStyles = css`
 
 export class Sidebar {
   render({ children }) {
-    return html`<nav class=${sidebarStyles}>${children}</nav>`;
+    return html`<nav className=${sidebarStyles}>${children}</nav>`;
   }
 }

--- a/packages/styleguide/src/components/SourceCode.js
+++ b/packages/styleguide/src/components/SourceCode.js
@@ -88,11 +88,11 @@ export class SourceCode {
     }
 
     if (status !== "ready") {
-      return html` <${Center} class=${loadingStyles}><${Spinner} /><//> `;
+      return html` <${Center} className=${loadingStyles}><${Spinner} /><//> `;
     }
 
     return html`
-      <pre class=${preStyles}><code class=${codeStyles} ref=${this
+      <pre className=${preStyles}><code className=${codeStyles} ref=${this
         ._setCodeRef}>${this._content}</code></pre>
     `;
   }

--- a/packages/styleguide/src/components/TopBar.js
+++ b/packages/styleguide/src/components/TopBar.js
@@ -66,16 +66,16 @@ export class TopBar {
 
   render({ logo, title }) {
     return html`
-      <header class=${topBarStyles}>
+      <header className=${topBarStyles}>
         <${Link}
           route="index"
           state=${{ scrollToTop: true }}
-          class=${homeStyles}
+          className=${homeStyles}
         >
-          <img src=${logo} class=${logoStyles} />
-          <span class=${brandStyles}>${title}</span>
+          <img src=${logo} className=${logoStyles} />
+          <span className=${brandStyles}>${title}</span>
         <//>
-        <div class=${buttonsStyles}>
+        <div className=${buttonsStyles}>
           <${DirectionSwitch} />
         </div>
       </header>

--- a/packages/styleguide/src/components/Welcome.js
+++ b/packages/styleguide/src/components/Welcome.js
@@ -8,6 +8,6 @@ const styles = css`
 
 export class Welcome {
   render() {
-    return html` <div class=${styles}>Hello</div> `;
+    return html` <div className=${styles}>Hello</div> `;
   }
 }

--- a/packages/view/src/index.spec.js
+++ b/packages/view/src/index.spec.js
@@ -942,7 +942,7 @@ describe("view", () => {
       const listener = sinon.spy();
 
       render(
-        html`<button @click=${listener}>click me</button>`,
+        html`<button onClick=${listener}>click me</button>`,
         store,
         container
       );
@@ -969,11 +969,11 @@ describe("view", () => {
           }
 
           render({ listener }) {
-            return html`<button
-              @click=${listener === "old" ? oldListener : newListener}
-            >
-              click me
-            </button>`;
+            return html`
+              <button onClick=${listener === "old" ? oldListener : newListener}>
+                click me
+              </button>
+            `;
           }
         }
 
@@ -1006,7 +1006,7 @@ describe("view", () => {
           }
 
           render({ enabled }) {
-            return html`<button @click=${enabled && listener}>
+            return html`<button onClick=${enabled && listener}>
               click me
             </button>`;
           }
@@ -1041,7 +1041,7 @@ describe("view", () => {
 
           render({ enabled }) {
             return enabled
-              ? html`<button @click=${listener}>click me</button>`
+              ? html`<button onClick=${listener}>click me</button>`
               : html`<button>click me</button>`;
           }
         }
@@ -1071,8 +1071,8 @@ describe("view", () => {
       const captureListener = sinon.spy();
 
       render(
-        html`<div @clickCapture=${captureListener}>
-          <button @click=${listener}>click me</button>
+        html`<div onClickCapture=${captureListener}>
+          <button onClick=${listener}>click me</button>
         </div>`,
         store,
         container
@@ -1101,7 +1101,7 @@ describe("view", () => {
 
           render({ listener }) {
             return html`<button
-              @clickCapture=${listener === "old" ? oldListener : newListener}
+              onClickCapture=${listener === "old" ? oldListener : newListener}
             >
               click me
             </button>`;
@@ -1137,7 +1137,7 @@ describe("view", () => {
           }
 
           render({ enabled }) {
-            return html`<button @clickCapture=${enabled && listener}>
+            return html`<button onClickCapture=${enabled && listener}>
               click me
             </button>`;
           }
@@ -1172,7 +1172,7 @@ describe("view", () => {
 
           render({ enabled }) {
             return enabled
-              ? html`<button @clickCapture=${listener}>click me</button>`
+              ? html`<button onClickCapture=${listener}>click me</button>`
               : html`<button>click me</button>`;
           }
         }

--- a/packages/view/src/vdom.js
+++ b/packages/view/src/vdom.js
@@ -304,6 +304,8 @@ const eventHandlerPropToEventName = (name) => {
   return `on${loweredEventName}` in document ? loweredEventName : eventName;
 };
 
+const mapPropName = (name) => (name === "className" ? "class" : name);
+
 const addEventListener = (dom, name, listener) => {
   if (listener) {
     dom.addEventListener(
@@ -368,7 +370,7 @@ class PrimitiveComponent {
         } else if (!value) {
           this._dom.removeAttribute(p);
         } else {
-          this._dom.setAttribute(p, value);
+          this._dom.setAttribute(mapPropName(p), value);
         }
       }
     }
@@ -430,7 +432,7 @@ class PrimitiveComponent {
         } else if (value === true) {
           this._dom.setAttribute(p, "");
         } else if (value) {
-          this._dom.setAttribute(p, value);
+          this._dom.setAttribute(mapPropName(p), value);
         }
       }
     }

--- a/packages/view/src/vdom.spec.js
+++ b/packages/view/src/vdom.spec.js
@@ -68,9 +68,9 @@ class Title {
 
 class Box {
   render({ title, children }) {
-    return html`<div class="box">
+    return html`<div className="box">
       <${Title}>${title}<//>
-      <div class="body">${children}</div>
+      <div className="body">${children}</div>
     </div>`;
   }
 }

--- a/packages/view/src/vdom.spec.js
+++ b/packages/view/src/vdom.spec.js
@@ -512,7 +512,7 @@ describe("vdom", () => {
       const entries = pickset([
         [word.map((w) => `data-${w}`), word],
         ["style", styles],
-        ["@click", handlers],
+        ["onClick", handlers],
         ["ref", handlers],
         ["disabled", bool],
         [".myProp", pickone([word, bool, undefined])],

--- a/scripts/IconPreview.ejs
+++ b/scripts/IconPreview.ejs
@@ -60,7 +60,7 @@ class IconCopyButton {
 
   render({ children }) {
     return html`
-      <button @click=${this.onClick} class=${copyStyles} title="Click to copy">
+      <button onClick=${this.onClick} class=${copyStyles} title="Click to copy">
         ${children}
       </button>
     `

--- a/scripts/IconPreview.ejs
+++ b/scripts/IconPreview.ejs
@@ -60,7 +60,7 @@ class IconCopyButton {
 
   render({ children }) {
     return html`
-      <button onClick=${this.onClick} class=${copyStyles} title="Click to copy">
+      <button onClick=${this.onClick} className=${copyStyles} title="Click to copy">
         ${children}
       </button>
     `
@@ -82,9 +82,9 @@ class IconsPage {
       <p>
         The icons come in two flavors – monochrome and two-tone. The primary
         fill/stroke will always be specified as
-        <code class="inline">currentColor</code> This means CSS text color style
+        <code className="inline">currentColor</code> This means CSS text color style
         will cascade to the icon. Two-tone icons can receive a secondary color
-        via the <code class="inline">fill</code> style property.
+        via the <code className="inline">fill</code> style property.
       </p>
       <${Example} src=${new URL("./IconUsage.js", import.meta.url)}
       >
@@ -102,7 +102,7 @@ class IconsPage {
       </p>
 <% for(let group of items) { -%>
       <${Heading} level=2><%-group.key%><//>
-      <div class=${columnStyles}>
+      <div className=${columnStyles}>
 <% for(let { name } of group.items) { -%>
          <${<%-name%>} />
          <${IconCopyButton}><%-name%><//>


### PR DESCRIPTION
* Use `on` as a prefix for event handlers instead of `@`
* Use `className` instead of `class`

This change will allow you to destructure the props without the need to renaming the. I found that it becomes pretty tedious to do this kind of mapping all over the place. It also raises familiarity with React. 

- [x] Test docs/components
- [x] Test examples/hackernews
- [x] Test examples/todomvc
- [x] Test examples/todomvc-api
- [x] Test examples/todomvc-model
- [x] Test examples/todomvc-preact
- [x] Test examples/todomvc-react
- [x] Test examples/todomvc-screenreader