### PR TITLE
Handle function payloads in the store

### DIFF
--- a/packages/store/src/Store.js
+++ b/packages/store/src/Store.js
@@ -4,8 +4,13 @@ export class Store {
   constructor(data) {
     this.cache = new Cache(data);
     this._apply = (action) => {
-      if (action.payload !== null) {
-        Object.entries(action.payload).forEach(([pathPattern, value]) => {
+      let payload = action.payload;
+      if (payload !== null) {
+        if (typeof payload === "function" && action.inputs) {
+          payload = payload(this.cache.get(action.inputs));
+        }
+
+        Object.entries(payload).forEach(([pathPattern, value]) => {
           this.cache.set(pathPattern, value);
         });
       }

--- a/packages/store/src/Store.spec.js
+++ b/packages/store/src/Store.spec.js
@@ -82,6 +82,33 @@ describe("store", () => {
         computedSpy(8);
       });
     });
+
+    describe("when the action payload is a function and the action has inputs", () => {
+      it("calls the payload with the inputs from the store", async () => {
+        const store = new Store({
+          global: { enabled: false },
+        });
+
+        const toggle = (path) => ({
+          inputs: { enabled: path },
+          payload: ({ enabled }) => ({
+            [path]: !enabled,
+          }),
+        });
+
+        await store.dispatch(toggle("global.enabled"));
+
+        expect(store.get(), "to equal", {
+          global: { enabled: true },
+        });
+
+        await store.dispatch(toggle("global.enabled"));
+
+        expect(store.get(), "to equal", {
+          global: { enabled: false },
+        });
+      });
+    });
   });
 
   describe("use", () => {


### PR DESCRIPTION
If no middleware has taken care of a function payload, the main store will deal with it.

This just means that you can count of function payloads always working as part of the platform.